### PR TITLE
Fixture on example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ func ExampleScrape_MetalSucks() {
 	// Load the HTML document (in real use, the type would be *goquery.Document)
 	var doc *Document
 	var e error
-
+	
+        // Initialize doc, (in real use, the method would be goquery.NewDocument)
 	if doc, e = NewDocument("http://metalsucks.net"); e != nil {
 		log.Fatal(e)
 	}


### PR DESCRIPTION
imported "github.com/PuerkitoBio/goquery", but if I didn't use goquery.NewDocument() method, the compiler would report "undefined: NewDocument" error
