### PR TITLE
add Selection.All()

### DIFF
--- a/iteration.go
+++ b/iteration.go
@@ -9,6 +9,16 @@ func (s *Selection) Each(f func(int, *Selection)) *Selection {
 	return s
 }
 
+// All returns all matched nodes as Selection objects, allowing you to iterate
+// over each matched element with with a loop.
+func (s *Selection) All() []*Selection {
+	l := make([]*Selection, 0, len(s.Nodes))
+	for i := range s.Nodes {
+		l = append(l, newSingleSelection(s.Nodes[i], s.document))
+	}
+	return l
+}
+
 // EachWithBreak iterates over a Selection object, executing a function for each
 // matched element. It is identical to Each except that it is possible to break
 // out of the loop by returning false in the callback function. It returns the


### PR DESCRIPTION
This was the only thing missing from your library that I really wanted.  I understand that using closures is the jQuery way, but it feels really awful in Go.  This method allows code like this:

``` go
for i, s := range doc.Find(".reviews-wrap article .review-rhs").All() {
        band := s.Find("h3").Text()
        title := s.Find("i").Text()
        fmt.Printf("Review %d: %s - %s\n", i, band, title)
}
```

Presently, I _think_ this might work, but it's pretty ugly:

``` go
for i, n := doc.Find(".reviews-wrap article .reviews-rhs").Nodes {
        s := doc.End().AddNodes(n)
        band := s.Find("h3").Text()
        ...
}
```
