### PR TITLE
add new method to handle HTML documents except UTF-8

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -24,6 +24,14 @@ func ExampleScrape_MetalSucks() {
 		title := s.Find("i").Text()
 		fmt.Printf("Review %d: %s - %s\n", i, band, title)
 	})
+
+	// In case of HTML except utf-8, use NewConvertedDocument method
+	other_doc, _ := NewConvertedDocument("http://mixi.jp/", "euc-jp")
+	other_doc.Find(".loginButton").Each(func(_ int, s *Selection) {
+		text, _ := s.Find("input").Attr("alt")
+		fmt.Printf("output: %s \n", text)
+	})
+
 	// To see the output of the Example while running the test suite (go test), simply
 	// remove the leading "x" before Output on the next line. This will cause the
 	// example to fail (all the "real" tests should pass).


### PR DESCRIPTION
This commit  adds new method to handle HTML documents other than UTF-8.

The new method is NewConvertedDocument(url string, charset string).

It takes two arguments.

First arg is  same as NewDocument method.  

Second arg is original character code of the website.

Return value is the same as NewDocument method. 

To convert character code, I use [iconv-go](https://github.com/djimenez/iconv-go).

Example is below.

``` go
    // In case of HTML except utf-8, use NewConvertedDocument method
    other_doc, _ := NewConvertedDocument("http://mixi.jp/", "euc-jp")
    other_doc.Find(".loginButton").Each(func(_ int, s *Selection) {
        text, _ := s.Find("input").Attr("alt")
        fmt.Printf("output: %s \n", text)
    })
```

I wrote this example in goquery/example_test.go.
