### PR TITLE
Add ReplaceWith*, Wrap*, and Unwrap

### DIFF
--- a/manipulation.go
+++ b/manipulation.go
@@ -232,6 +232,19 @@ func (s *Selection) ReplaceWithNodes(ns ...*html.Node) *Selection {
 	return s.Remove()
 }
 
+// Unwrap removes the parents of the set of matched elements, leaving the matched
+// elements (and their siblings, if any) in their place.
+// It returns the original selection.
+func (s *Selection) Unwrap() *Selection {
+	s.Parent().Each(func(i int, ss *Selection) {
+		if ss.Nodes[0].Data != "body" {
+			ss.ReplaceWithSelection(ss.Contents())
+		}
+	})
+
+	return s
+}
+
 // Wrap wraps each element in the set of matched elements inside the first
 // element matched by the given selector. The matched child is cloned before
 // being inserted into the document.

--- a/manipulation_test.go
+++ b/manipulation_test.go
@@ -230,6 +230,28 @@ func TestReplaceWithSelection(t *testing.T) {
 	printSel(t, doc.Selection)
 }
 
+func TestUnwrap(t *testing.T) {
+	doc := Doc2Clone()
+
+	doc.Find("#nf5").Unwrap()
+	assertLength(t, doc.Find("#foot").Nodes, 0)
+
+	assertLength(t, doc.Find("body > #nf1").Nodes, 1)
+	assertLength(t, doc.Find("body > #nf5").Nodes, 1)
+
+	printSel(t, doc.Selection)
+}
+
+func TestUnwrapBody(t *testing.T) {
+	doc := Doc2Clone()
+
+	doc.Find("#main").Unwrap()
+	assertLength(t, doc.Find("body").Nodes, 1)
+	assertLength(t, doc.Find("body > #main").Nodes, 1)
+
+	printSel(t, doc.Selection)
+}
+
 func TestWrap(t *testing.T) {
 	doc := Doc2Clone()
 	doc.Find("#nf1").Wrap("#nf2")


### PR DESCRIPTION
Seems I was a little hasty with my first pull request and forgot to include the manipulation methods at the end of the alphabet. Here they are!
