### PR TITLE
cascadia paths

### DIFF
--- a/expand.go
+++ b/expand.go
@@ -1,8 +1,8 @@
 package goquery
 
 import (
-	"code.google.com/p/cascadia"
-	"golang.org/x/net/html"
+"github.com/andybalholm/cascadia"
+"golang.org/x/net/html"
 )
 
 // Add adds the selector string's matching nodes to those in the current

--- a/filter.go
+++ b/filter.go
@@ -1,8 +1,8 @@
 package goquery
 
 import (
-	"code.google.com/p/cascadia"
-	"golang.org/x/net/html"
+"github.com/andybalholm/cascadia"
+"golang.org/x/net/html"
 )
 
 // Filter reduces the set of matched elements to those that match the selector string.
@@ -104,7 +104,7 @@ func (s *Selection) HasNodes(nodes ...*html.Node) *Selection {
 			}
 		}
 		return false
-	})
+		})
 }
 
 // HasSelection reduces the set of matched elements to those that have a
@@ -136,7 +136,7 @@ func winnow(sel *Selection, m Matcher, keep bool) []*html.Node {
 	// Use grep
 	return grep(sel, func(i int, s *Selection) bool {
 		return !m.Match(s.Get(0))
-	})
+		})
 }
 
 // Filter based on an array of nodes, and the indicator to keep (Filter) or
@@ -144,7 +144,7 @@ func winnow(sel *Selection, m Matcher, keep bool) []*html.Node {
 func winnowNodes(sel *Selection, nodes []*html.Node, keep bool) []*html.Node {
 	return grep(sel, func(i int, s *Selection) bool {
 		return isInSlice(nodes, s.Get(0)) == keep
-	})
+		})
 }
 
 // Filter based on a function test, and the indicator to keep (Filter) or
@@ -152,5 +152,5 @@ func winnowNodes(sel *Selection, nodes []*html.Node, keep bool) []*html.Node {
 func winnowFunction(sel *Selection, f func(int, *Selection) bool, keep bool) []*html.Node {
 	return grep(sel, func(i int, s *Selection) bool {
 		return f(i, s) == keep
-	})
+		})
 }

--- a/manipulation.go
+++ b/manipulation.go
@@ -1,10 +1,10 @@
 package goquery
 
 import (
-	"strings"
+"strings"
 
-	"code.google.com/p/cascadia"
-	"golang.org/x/net/html"
+"github.com/andybalholm/cascadia"
+"golang.org/x/net/html"
 )
 
 // After applies the selector from the root document and inserts the matched elements
@@ -52,7 +52,7 @@ func (s *Selection) AfterNodes(ns ...*html.Node) *Selection {
 		if sn.Parent != nil {
 			sn.Parent.InsertBefore(n, sn.NextSibling)
 		}
-	})
+		})
 }
 
 // Append appends the elements specified by the selector to the end of each element
@@ -96,7 +96,7 @@ func (s *Selection) AppendHtml(html string) *Selection {
 func (s *Selection) AppendNodes(ns ...*html.Node) *Selection {
 	return s.manipulateNodes(ns, false, func(sn *html.Node, n *html.Node) {
 		sn.AppendChild(n)
-	})
+		})
 }
 
 // Before inserts the matched elements before each element in the set of matched elements.
@@ -136,7 +136,7 @@ func (s *Selection) BeforeNodes(ns ...*html.Node) *Selection {
 		if sn.Parent != nil {
 			sn.Parent.InsertBefore(n, sn)
 		}
-	})
+		})
 }
 
 // Clone creates a deep copy of the set of matched nodes. The new nodes will not be
@@ -198,7 +198,7 @@ func (s *Selection) PrependNodes(ns ...*html.Node) *Selection {
 		// sn.FirstChild may be nil, in which case this functions like
 		// sn.AppendChild()
 		sn.InsertBefore(n, sn.FirstChild)
-	})
+		})
 }
 
 // Remove removes the set of matched elements from the document.
@@ -282,7 +282,7 @@ func (s *Selection) Unwrap() *Selection {
 		if ss.Nodes[0].Data != "body" {
 			ss.ReplaceWithSelection(ss.Contents())
 		}
-	})
+		})
 
 	return s
 }
@@ -334,7 +334,7 @@ func (s *Selection) WrapNode(n *html.Node) *Selection {
 func (s *Selection) wrapNodes(ns ...*html.Node) *Selection {
 	s.Each(func(i int, ss *Selection) {
 		ss.wrapAllNodes(ns...)
-	})
+		})
 
 	return s
 }
@@ -467,7 +467,7 @@ func (s *Selection) wrapInnerNodes(ns ...*html.Node) *Selection {
 		} else {
 			s.AppendNodes(cloneNode(ns[0]))
 		}
-	})
+		})
 
 	return s
 }

--- a/query.go
+++ b/query.go
@@ -1,8 +1,8 @@
 package goquery
 
 import (
-	"code.google.com/p/cascadia"
-	"golang.org/x/net/html"
+"github.com/andybalholm/cascadia"
+"golang.org/x/net/html"
 )
 
 // Is checks the current matched set of elements against a selector and

--- a/traversal.go
+++ b/traversal.go
@@ -1,8 +1,8 @@
 package goquery
 
 import (
-	"code.google.com/p/cascadia"
-	"golang.org/x/net/html"
+"github.com/andybalholm/cascadia"
+"golang.org/x/net/html"
 )
 
 type siblingType int
@@ -53,7 +53,7 @@ func (s *Selection) FindNodes(nodes ...*html.Node) *Selection {
 			return []*html.Node{n}
 		}
 		return nil
-	}))
+		}))
 }
 
 // Contents gets the children of each element in the Selection,
@@ -140,7 +140,7 @@ func (s *Selection) ClosestMatcher(m Matcher) *Selection {
 			}
 		}
 		return nil
-	}))
+		}))
 }
 
 // ClosestNodes gets the first element that matches one of the nodes by testing the
@@ -155,7 +155,7 @@ func (s *Selection) ClosestNodes(nodes ...*html.Node) *Selection {
 			}
 		}
 		return nil
-	}))
+		}))
 }
 
 // ClosestSelection gets the first element that matches one of the nodes in the
@@ -547,7 +547,7 @@ func findWithMatcher(nodes []*html.Node, m Matcher) []*html.Node {
 			}
 		}
 		return
-	})
+		})
 }
 
 // Internal implementation to get all parent nodes, stopping at the specified
@@ -570,7 +570,7 @@ func getParentsNodes(nodes []*html.Node, stopm Matcher, stopNodes []*html.Node) 
 			}
 		}
 		return
-	})
+		})
 }
 
 // Internal implementation of sibling nodes that return a raw slice of matches.
@@ -596,7 +596,7 @@ func getSiblingNodes(nodes []*html.Node, st siblingType, untilm Matcher, untilNo
 
 	return mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
 		return getChildrenWithSiblingType(n.Parent, st, n, f)
-	})
+		})
 }
 
 // Gets the children nodes of each node in the specified slice of nodes,
@@ -604,7 +604,7 @@ func getSiblingNodes(nodes []*html.Node, st siblingType, untilm Matcher, untilNo
 func getChildrenNodes(nodes []*html.Node, st siblingType) []*html.Node {
 	return mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
 		return getChildrenWithSiblingType(n, st, nil, nil)
-	})
+		})
 }
 
 // Gets the children of the specified parent, based on the requested sibling
@@ -679,7 +679,7 @@ func getParentNodes(nodes []*html.Node) []*html.Node {
 			return []*html.Node{n.Parent}
 		}
 		return nil
-	})
+		})
 }
 
 // Internal map function used by many traversing methods. Takes the source nodes


### PR DESCRIPTION
Go get cannot install goquery due to cascadia having moved from google code to github.
The source files have been changed to make use of the new cascadia sources.