### PR TITLE
Keep document's charset and use it on returning values of nodes

### DIFF
--- a/property.go
+++ b/property.go
@@ -17,7 +17,8 @@ func (s *Selection) Attr(attrName string) (val string, exists bool) {
 	if len(s.Nodes) == 0 {
 		return
 	}
-	return getAttributeValue(attrName, s.Nodes[0])
+	val, exists = getAttributeValue(attrName, s.Nodes[0])
+	return s.document.DecodeString(val), exists
 }
 
 // AttrOr works like Attr but returns default value if attribute is not present.

--- a/type.go
+++ b/type.go
@@ -1,12 +1,16 @@
 package goquery
 
 import (
+	"bytes"
 	"errors"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
 	"golang.org/x/net/html"
+	"golang.org/x/net/html/charset"
+	"golang.org/x/text/encoding"
 )
 
 // Document represents an HTML document to be manipulated. Unlike jQuery, which
@@ -18,12 +22,24 @@ type Document struct {
 	*Selection
 	Url      *url.URL
 	rootNode *html.Node
+	charset  *encoding.Decoder
+}
+
+// DecodeString decodes given string by this document's charset.
+func (doc *Document) DecodeString(src string) string {
+	if doc.charset == nil {
+		return src
+	}
+	if dest, e := doc.charset.String(src); e == nil {
+		return dest
+	}
+	return src
 }
 
 // NewDocumentFromNode is a Document constructor that takes a root html Node
 // as argument.
 func NewDocumentFromNode(root *html.Node) *Document {
-	return newDocument(root, nil)
+	return newDocument(root, nil, nil)
 }
 
 // NewDocument is a Document constructor that takes a string URL as argument.
@@ -44,11 +60,7 @@ func NewDocument(url string) (*Document, error) {
 // provided reader is never closed by this call, it is the responsibility
 // of the caller to close it if required.
 func NewDocumentFromReader(r io.Reader) (*Document, error) {
-	root, e := html.Parse(r)
-	if e != nil {
-		return nil, e
-	}
-	return newDocument(root, nil), nil
+	return parseReader(r, nil)
 }
 
 // NewDocumentFromResponse is another Document constructor that takes an http response as argument.
@@ -63,25 +75,28 @@ func NewDocumentFromResponse(res *http.Response) (*Document, error) {
 		return nil, errors.New("Response.Request is nil")
 	}
 
-	// Parse the HTML into nodes
-	root, e := html.Parse(res.Body)
+	return parseReader(res.Body, res.Request.URL)
+}
+
+func parseReader(r io.Reader, url *url.URL) (*Document, error) {
+	b, _ := ioutil.ReadAll(r)
+	enc, _, _ := charset.DetermineEncoding(b, "text/html")
+	root, e := html.Parse(bytes.NewReader(b))
 	if e != nil {
 		return nil, e
 	}
-
-	// Create and fill the document
-	return newDocument(root, res.Request.URL), nil
+	return newDocument(root, url, enc.NewDecoder()), nil
 }
 
 // CloneDocument creates a deep-clone of a document.
 func CloneDocument(doc *Document) *Document {
-	return newDocument(cloneNode(doc.rootNode), doc.Url)
+	return newDocument(cloneNode(doc.rootNode), doc.Url, nil)
 }
 
 // Private constructor, make sure all fields are correctly filled.
-func newDocument(root *html.Node, url *url.URL) *Document {
+func newDocument(root *html.Node, url *url.URL, decoder *encoding.Decoder) *Document {
 	// Create and fill the document
-	d := &Document{nil, url, root}
+	d := &Document{Selection: nil, Url: url, rootNode: root, charset: decoder}
 	d.Selection = newSingleSelection(root, d)
 	return d
 }


### PR DESCRIPTION
I respect this very useful library. It helps me always!

This is just a suggestion.
It failed to return valid string when parsing multibyte encoded HTML document (like EUC_JP, ShiftJIS, or other multibyte encodings). So I fixed `Document` struct and `Attr` method a bit.

I wrote it as a wrap function of `Attr`, however, root document still have encoding, it might be better to let users use `document.DecodeString` in application layer.

Feel free to close this pull-request or I'm so glad if you leave some comment.

Thank you!
