### PR TITLE
Text nodes are written twice in selection.Text()

### DIFF
--- a/property.go
+++ b/property.go
@@ -65,7 +65,7 @@ func (s *Selection) Text() string {
 	// Slightly optimized vs calling Each: no single selection object created
 	var f func(*html.Node)
 	f = func(n *html.Node) {
-		if n.Type == html.TextNode {
+		if n.Type == html.TextNode && "" == n.DataAtom.String() {
 			// Keep newlines and spaces, like jQuery
 			buf.WriteString(n.Data)
 		}


### PR DESCRIPTION
I think this is a regression of commit c0b805c7dc712d7397ff1c76ae1ac6211a910e50 (pull request #142): 
If a document has an <img> or <a> tag which embeds a text node, calling Text() on it will return the text node twice, as both the <img> or <a> tag and the inner data nodes are considered as independent nodes in the loop, so the textual content is written twice.