### PR TITLE
Removed unnecessary conditional check

### DIFF
--- a/query.go
+++ b/query.go
@@ -5,11 +5,7 @@ import "golang.org/x/net/html"
 // Is checks the current matched set of elements against a selector and
 // returns true if at least one of these elements matches.
 func (s *Selection) Is(selector string) bool {
-	if len(s.Nodes) > 0 {
-		return s.IsMatcher(compileMatcher(selector))
-	}
-
-	return false
+	return s.IsMatcher(compileMatcher(selector))
 }
 
 // IsMatcher checks the current matched set of elements against a matcher and


### PR DESCRIPTION
`IsMatcher()` returns false if `len(s.Nodes) !> 0`, so `Is()` was double checking if `len(s.Nodes) > 0`