### PR TITLE
Fixes #232 - make .Slice's end argument optional.  If not provided, d…

### DIFF
--- a/array.go
+++ b/array.go
@@ -36,14 +36,20 @@ func (s *Selection) Eq(index int) *Selection {
 
 // Slice reduces the set of matched elements to a subset specified by a range
 // of indices.
-func (s *Selection) Slice(start, end int) *Selection {
+func (s *Selection) Slice(start int, end ...int) *Selection {
+	var e int
+	if len(end) > 0 {
+		e = end[0]
+	} else {
+		e = len(s.Nodes)
+	}
 	if start < 0 {
 		start += len(s.Nodes)
 	}
-	if end < 0 {
-		end += len(s.Nodes)
+	if e < 0 {
+		e += len(s.Nodes)
 	}
-	return pushStack(s, s.Nodes[start:end])
+	return pushStack(s, s.Nodes[start:e])
 }
 
 // Get retrieves the underlying node at the specified index.

--- a/array_test.go
+++ b/array_test.go
@@ -146,6 +146,11 @@ func TestSliceRollback(t *testing.T) {
 	assertEqual(t, sel, sel2)
 }
 
+func TestSliceNoEnd(t *testing.T) {
+	sel := Doc().Find(".pvk-content").Slice(1)
+	assertLength(t, sel.Nodes, 2)
+}
+
 func TestGet(t *testing.T) {
 	sel := Doc().Find(".pvk-content")
 	node := sel.Get(1)


### PR DESCRIPTION
make .Slice's end argument optional.  If not provided, default to the length of the nodes. Added unit test.