### PR TITLE
Fixes #178 - Send context to parseHtml

### DIFF
--- a/manipulation.go
+++ b/manipulation.go
@@ -39,8 +39,14 @@ func (s *Selection) AfterSelection(sel *Selection) *Selection {
 // AfterHtml parses the html and inserts it after the set of matched elements.
 //
 // This follows the same rules as Selection.Append.
-func (s *Selection) AfterHtml(html string) *Selection {
-	return s.AfterNodes(parseHtml(html)...)
+func (s *Selection) AfterHtml(htmlStr string) *Selection {
+	return s.eachNodeHtml(htmlStr, true, func(node *html.Node, nodes []*html.Node) {
+		for _, n := range nodes {
+			if node.Parent != nil {
+				node.Parent.InsertBefore(n, node.NextSibling)
+			}
+		}
+	})
 }
 
 // AfterNodes inserts the nodes after each element in the set of matched elements.
@@ -85,8 +91,12 @@ func (s *Selection) AppendSelection(sel *Selection) *Selection {
 }
 
 // AppendHtml parses the html and appends it to the set of matched elements.
-func (s *Selection) AppendHtml(html string) *Selection {
-	return s.AppendNodes(parseHtml(html)...)
+func (s *Selection) AppendHtml(htmlStr string) *Selection {
+	return s.eachNodeHtml(htmlStr, false, func(node *html.Node, nodes []*html.Node) {
+		for _, n := range nodes {
+			node.AppendChild(n)
+		}
+	})
 }
 
 // AppendNodes appends the specified nodes to each node in the set of matched elements.
@@ -123,8 +133,14 @@ func (s *Selection) BeforeSelection(sel *Selection) *Selection {
 // BeforeHtml parses the html and inserts it before the set of matched elements.
 //
 // This follows the same rules as Selection.Append.
-func (s *Selection) BeforeHtml(html string) *Selection {
-	return s.BeforeNodes(parseHtml(html)...)
+func (s *Selection) BeforeHtml(htmlStr string) *Selection {
+	return s.eachNodeHtml(htmlStr, true, func(node *html.Node, nodes []*html.Node) {
+		for _, n := range nodes {
+			if node.Parent != nil {
+				node.Parent.InsertBefore(n, node)
+			}
+		}
+	})
 }
 
 // BeforeNodes inserts the nodes before each element in the set of matched elements.
@@ -184,8 +200,12 @@ func (s *Selection) PrependSelection(sel *Selection) *Selection {
 }
 
 // PrependHtml parses the html and prepends it to the set of matched elements.
-func (s *Selection) PrependHtml(html string) *Selection {
-	return s.PrependNodes(parseHtml(html)...)
+func (s *Selection) PrependHtml(htmlStr string) *Selection {
+	return s.eachNodeHtml(htmlStr, false, func(node *html.Node, nodes []*html.Node) {
+		for _, n := range nodes {
+			node.InsertBefore(n, node.FirstChild)
+		}
+	})
 }
 
 // PrependNodes prepends the specified nodes to each node in the set of
@@ -256,8 +276,15 @@ func (s *Selection) ReplaceWithSelection(sel *Selection) *Selection {
 // It returns the removed elements.
 //
 // This follows the same rules as Selection.Append.
-func (s *Selection) ReplaceWithHtml(html string) *Selection {
-	return s.ReplaceWithNodes(parseHtml(html)...)
+func (s *Selection) ReplaceWithHtml(htmlStr string) *Selection {
+	s.eachNodeHtml(htmlStr, true, func(node *html.Node, nodes []*html.Node) {
+		for _, n := range nodes {
+			if node.Parent != nil {
+				node.Parent.InsertBefore(n, node.NextSibling)
+			}
+		}
+	})
+	return s.Remove()
 }
 
 // ReplaceWithNodes replaces each element in the set of matched elements with
@@ -272,8 +299,17 @@ func (s *Selection) ReplaceWithNodes(ns ...*html.Node) *Selection {
 
 // SetHtml sets the html content of each element in the selection to
 // specified html string.
-func (s *Selection) SetHtml(html string) *Selection {
-	return setHtmlNodes(s, parseHtml(html)...)
+func (s *Selection) SetHtml(htmlStr string) *Selection {
+	for _, context := range s.Nodes {
+		for c := context.FirstChild; c != nil; c = context.FirstChild {
+			context.RemoveChild(c)
+		}
+	}
+	return s.eachNodeHtml(htmlStr, true, func(node *html.Node, nodes []*html.Node) {
+		for _, n := range nodes {
+			node.AppendChild(n)
+		}
+	})
 }
 
 // SetText sets the content of each element in the selection to specified content.
@@ -329,8 +365,23 @@ func (s *Selection) WrapSelection(sel *Selection) *Selection {
 // most child of the given HTML.
 //
 // It returns the original set of elements.
-func (s *Selection) WrapHtml(html string) *Selection {
-	return s.wrapNodes(parseHtml(html)...)
+func (s *Selection) WrapHtml(htmlStr string) *Selection {
+	nodesMap := make(map[html.NodeType][]*html.Node)
+	var parent *html.Node
+	for _, context := range s.Nodes {
+		if context.Parent != nil {
+			parent = context.Parent
+		} else {
+			parent = &html.Node{Type: html.ElementNode}
+		}
+		nodes, found := nodesMap[parent.Type]
+		if !found {
+			nodes = parseHtmlWithContext(htmlStr, parent)
+			nodesMap[parent.Type] = nodes
+		}
+		newSingleSelection(context, s.document).wrapAllNodes(cloneNodes(nodes)...)
+	}
+	return s
 }
 
 // WrapNode wraps each element in the set of matched elements inside the inner-
@@ -382,8 +433,18 @@ func (s *Selection) WrapAllSelection(sel *Selection) *Selection {
 // document.
 //
 // It returns the original set of elements.
-func (s *Selection) WrapAllHtml(html string) *Selection {
-	return s.wrapAllNodes(parseHtml(html)...)
+func (s *Selection) WrapAllHtml(htmlStr string) *Selection {
+	var context *html.Node
+	var nodes []*html.Node
+	if len(s.Nodes) > 0 {
+		context = s.Nodes[0]
+		if context.Parent != nil {
+			nodes = parseHtmlWithContext(htmlStr, context)
+		} else {
+			nodes = parseHtml(htmlStr)
+		}
+	}
+	return s.wrapAllNodes(nodes...)
 }
 
 func (s *Selection) wrapAllNodes(ns ...*html.Node) *Selection {
@@ -452,8 +513,17 @@ func (s *Selection) WrapInnerSelection(sel *Selection) *Selection {
 // cloned before being inserted into the document.
 //
 // It returns the original set of elements.
-func (s *Selection) WrapInnerHtml(html string) *Selection {
-	return s.wrapInnerNodes(parseHtml(html)...)
+func (s *Selection) WrapInnerHtml(htmlStr string) *Selection {
+	nodesMap := make(map[html.NodeType][]*html.Node)
+	for _, context := range s.Nodes {
+		nodes, found := nodesMap[context.Type]
+		if !found {
+			nodes = parseHtmlWithContext(htmlStr, context)
+			nodesMap[context.Type] = nodes
+		}
+		newSingleSelection(context, s.document).wrapInnerNodes(cloneNodes(nodes)...)
+	}
+	return s
 }
 
 // WrapInnerNode wraps an HTML structure, matched by the given selector, around
@@ -487,6 +557,16 @@ func parseHtml(h string) []*html.Node {
 	// Errors are only returned when the io.Reader returns any error besides
 	// EOF, but strings.Reader never will
 	nodes, err := html.ParseFragment(strings.NewReader(h), &html.Node{Type: html.ElementNode})
+	if err != nil {
+		panic("goquery: failed to parse HTML: " + err.Error())
+	}
+	return nodes
+}
+
+func parseHtmlWithContext(h string, context *html.Node) []*html.Node {
+	// Errors are only returned when the io.Reader returns any error besides
+	// EOF, but strings.Reader never will
+	nodes, err := html.ParseFragment(strings.NewReader(h), context)
 	if err != nil {
 		panic("goquery: failed to parse HTML: " + err.Error())
 	}
@@ -570,5 +650,26 @@ func (s *Selection) manipulateNodes(ns []*html.Node, reverse bool,
 		}
 	}
 
+	return s
+}
+
+func (s *Selection) eachNodeHtml(htmlStr string, parent bool, fn func(n *html.Node, nodes []*html.Node)) *Selection {
+	nodesMap := make(map[html.NodeType][]*html.Node)
+	var context *html.Node
+	for _, n := range s.Nodes {
+		if parent {
+			context = n.Parent
+		} else {
+			context = n
+		}
+		if context != nil {
+			nodes, found := nodesMap[context.Type]
+			if !found {
+				nodes = parseHtmlWithContext(htmlStr, context)
+				nodesMap[context.Type] = nodes
+			}
+			fn(n, cloneNodes(nodes))
+		}
+	}
 	return s
 }

--- a/manipulation_test.go
+++ b/manipulation_test.go
@@ -56,6 +56,13 @@ func TestAfterHtml(t *testing.T) {
 	printSel(t, doc.Selection)
 }
 
+func TestAfterHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr td").AfterHtml("<td>Test</td>")
+	assertLength(t, doc.Find("table tr td").Nodes, 14)
+	printSel(t, doc.Selection)
+}
+
 func TestAppend(t *testing.T) {
 	doc := Doc2Clone()
 	doc.Find("#main").Append("#nf6")
@@ -113,6 +120,15 @@ func TestAppendHtml(t *testing.T) {
 	printSel(t, doc.Selection)
 }
 
+func TestAppendHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr").AppendHtml("<td class='new-node'>new node</td>")
+
+	assertLength(t, doc.Find("table td").Nodes, 11)
+	assertLength(t, doc.Find("table tr td.new-node:last-child").Nodes, 4)
+	printSel(t, doc.Selection)
+}
+
 func TestBefore(t *testing.T) {
 	doc := Doc2Clone()
 	doc.Find("#main").Before("#nf6")
@@ -148,6 +164,14 @@ func TestBeforeHtml(t *testing.T) {
 	doc.Find("#main").BeforeHtml("<strong>new node</strong>")
 
 	assertLength(t, doc.Find("body > strong:first-child").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestBeforeHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr td:first-child").BeforeHtml("<td class='new-node'>new node</td>")
+
+	assertLength(t, doc.Find("table td.new-node:first-child").Nodes, 3)
 	printSel(t, doc.Selection)
 }
 
@@ -218,6 +242,15 @@ func TestPrependHtml(t *testing.T) {
 	printSel(t, doc.Selection)
 }
 
+func TestPrependHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr").PrependHtml("<td class='new-node'>new node</td>")
+
+	assertLength(t, doc.Find("table td").Nodes, 11)
+	assertLength(t, doc.Find("table tr td.new-node:first-child").Nodes, 4)
+	printSel(t, doc.Selection)
+}
+
 func TestRemove(t *testing.T) {
 	doc := Doc2Clone()
 	doc.Find("#nf1").Remove()
@@ -278,6 +311,15 @@ func TestReplaceWithHtml(t *testing.T) {
 	printSel(t, doc.Selection)
 }
 
+func TestReplaceWithHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table th").ReplaceWithHtml("<td>Test</td><td>Replace</td>")
+
+	assertLength(t, doc.Find("table th").Nodes, 0)
+	assertLength(t, doc.Find("table tr:first-child td").Nodes, 6)
+	printSel(t, doc.Selection)
+}
+
 func TestSetHtml(t *testing.T) {
 	doc := Doc2Clone()
 	q := doc.Find("#main, #foot")
@@ -310,6 +352,15 @@ func TestSetHtmlEmpty(t *testing.T) {
 
 	assertLength(t, doc.Find("#main").Nodes, 1)
 	assertLength(t, doc.Find("#main").Children().Nodes, 0)
+	printSel(t, doc.Selection)
+}
+
+func TestSetHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr").SetHtml("<td class='new-node'>Test</td>")
+
+	assertLength(t, doc.Find("table th").Nodes, 0)
+	assertLength(t, doc.Find("table td.new-node").Nodes, 4)
 	printSel(t, doc.Selection)
 }
 

--- a/type_test.go
+++ b/type_test.go
@@ -53,6 +53,10 @@ func DocB() *Document {
 	return docB
 }
 
+func DocBClone() *Document {
+	return CloneDocument(DocB())
+}
+
 func DocW() *Document {
 	if docW == nil {
 		docW = loadDoc("gowiki.html")


### PR DESCRIPTION
This creates a new function `parseHtmlWithContext`, which behaves just like `parseHtml` but takes an `*html.Node` as context.  

It also create a function `eachNodeHtml` which will iterate over each node in a selection, check to see if we have parsed html for this node type already, and if not, will call `parseHtmlWithContext` with either the current node, or it's parent, depending on whether you passed `parent` as `true` or `false`.

It also changes `AfterHtml`, `AppendHtml`, `BeforeHtml`, `PrependHtml`, `ReplaceWithHtml`, `SetHtml`, `WrapHtml`, `WrapAllHtml`, and `WrapInnerHtml` to use one or both of these functions.

New tests were added for all except the `WrapHtml*` functions - changing these functions may have been unncessary - I couldn't think of a way to test this - Go automatically wraps `tr` elements in `tbody`, so I can't wrap those, and I can't think of any other situation that this would occur in.