### PR TITLE
Add a whitespace when encountering a br node

### DIFF
--- a/property.go
+++ b/property.go
@@ -68,6 +68,8 @@ func (s *Selection) Text() string {
 		if n.Type == html.TextNode {
 			// Keep newlines and spaces, like jQuery
 			buf.WriteString(n.Data)
+		} else if n.Data == "br" {
+			buf.WriteString(" ")
 		}
 		if n.FirstChild != nil {
 			for c := n.FirstChild; c != nil; c = c.NextSibling {

--- a/property_test.go
+++ b/property_test.go
@@ -102,6 +102,16 @@ func TestText3(t *testing.T) {
 	}
 }
 
+func TestText4(t *testing.T) {
+	txt := Doc().Find(".hero-unit .container-fluid .row-fluid:nth-child(3)").Text()
+		if ok, e := regexp.MatchString(`^\s+Beta Version\.\s+Things may change\.\s+Or disappear\.\s+$`, txt); !ok || e != nil {
+		t.Errorf("Expected text to be Beta Version. Things may change. Or disappear., found %s.", txt)
+		if e != nil {
+			t.Logf("Error: %s.", e.Error())
+		}
+	}
+}
+
 func TestHtml(t *testing.T) {
 	txt, e := Doc().Find("h1").Html()
 	if e != nil {

--- a/property_test.go
+++ b/property_test.go
@@ -103,7 +103,7 @@ func TestText3(t *testing.T) {
 }
 
 func TestText4(t *testing.T) {
-	txt := Doc().Find(".hero-unit .container-fluid .row-fluid:nth-child(3)").Text()
+	txt := Doc().Find(".hero-unit .container-fluid #cf2-5").Text()
 		if ok, e := regexp.MatchString(`^\s+Beta Version\.\s+Things may change\.\s+Or disappear\.\s+$`, txt); !ok || e != nil {
 		t.Errorf("Expected text to be Beta Version. Things may change. Or disappear., found %s.", txt)
 		if e != nil {

--- a/testdata/page.html
+++ b/testdata/page.html
@@ -37,6 +37,11 @@
                                     <strong>Beta Version.</strong> Things may change. Or disappear. Or fail miserably. If it's the latter, <a href="https://github.com/PuerkitoBio/Provok.in-issues" target="_blank" class="link">please file an issue.</a>
                                 </div>
                             </div>
+                            <div class="row-fluid" id="cf2-3">
+                                <div class="span12 alert alert-error">
+                                    <strong>Beta Version.</strong> Things may change.<br/>Or disappear.
+                                </div>
+                            </div>
                             <div ng-cloak="" ng-show="isLoggedOut() &amp;&amp; !hideLogin" class="row-fluid" id="cf2-3">
                                 <a ng-href="{{ROUTES.login}}" class="btn btn-primary">Sign in. Painless.</a> <span>or</span> <a ng-href="{{ROUTES.help}}" class="link">learn more about provok.in.</a>
                             </div>

--- a/testdata/page.html
+++ b/testdata/page.html
@@ -37,16 +37,16 @@
                                     <strong>Beta Version.</strong> Things may change. Or disappear. Or fail miserably. If it's the latter, <a href="https://github.com/PuerkitoBio/Provok.in-issues" target="_blank" class="link">please file an issue.</a>
                                 </div>
                             </div>
-                            <div class="row-fluid" id="cf2-3">
-                                <div class="span12 alert alert-error">
-                                    <strong>Beta Version.</strong> Things may change.<br/>Or disappear.
-                                </div>
-                            </div>
                             <div ng-cloak="" ng-show="isLoggedOut() &amp;&amp; !hideLogin" class="row-fluid" id="cf2-3">
                                 <a ng-href="{{ROUTES.login}}" class="btn btn-primary">Sign in. Painless.</a> <span>or</span> <a ng-href="{{ROUTES.help}}" class="link">learn more about provok.in.</a>
                             </div>
                             <div ng-cloak="" ng-show="isLoggedIn()" class="row-fluid logged-in-state" id="cf2-4">
                                 <span>Welcome,</span> <a ng-href="{{ROUTES.profile}}" class="link">{{getUserName()}}</a> <span>(</span> <a ng-click="doLogout($event)" class="link">logout</a> <span>)</span>
+                            </div>
+                            <div id="cf2-5">
+                                <div>
+                                    <strong>Beta Version.</strong> Things may change.<br/>Or disappear.
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/traversal_test.go
+++ b/traversal_test.go
@@ -378,7 +378,7 @@ func TestPrevFilteredRollback(t *testing.T) {
 
 func TestNextAll(t *testing.T) {
 	sel := Doc().Find("#cf2 div:nth-child(1)").NextAll()
-	assertLength(t, sel.Nodes, 3)
+	assertLength(t, sel.Nodes, 4)
 }
 
 func TestNextAllRollback(t *testing.T) {
@@ -389,7 +389,7 @@ func TestNextAllRollback(t *testing.T) {
 
 func TestNextAll2(t *testing.T) {
 	sel := Doc().Find("div[ng-cloak]").NextAll()
-	assertLength(t, sel.Nodes, 1)
+	assertLength(t, sel.Nodes, 2)
 }
 
 func TestNextAllNone(t *testing.T) {


### PR DESCRIPTION
Prevents br nodes from causing text from after the br node to be
directly after the text before the br node without any whitespace.