### PR TITLE
Fixes #293, making the resulting node collection from .Add() sorted in document order

### DIFF
--- a/expand.go
+++ b/expand.go
@@ -6,6 +6,11 @@ import "golang.org/x/net/html"
 // selection and returns a new Selection object.
 // The selector string is run in the context of the document of the current
 // Selection object.
+// Do not assume that this method appends the elements to the existing collection
+// in the order they are passed to the .Add() method.
+// When all elements are members of the same document, the resulting collection
+// from .Add() will be sorted in document order; that is, in order of each element's appearance in the document.
+// If the collection consists of elements from different documents or ones not in any document, the sort order is undefined.
 func (s *Selection) Add(selector string) *Selection {
 	return s.AddNodes(findWithMatcher([]*html.Node{s.document.rootNode}, compileMatcher(selector))...)
 }
@@ -14,12 +19,14 @@ func (s *Selection) Add(selector string) *Selection {
 // selection and returns a new Selection object.
 // The matcher is run in the context of the document of the current
 // Selection object.
+// Nodes ordering in the result collection follows the same rules as .Add().
 func (s *Selection) AddMatcher(m Matcher) *Selection {
 	return s.AddNodes(findWithMatcher([]*html.Node{s.document.rootNode}, m)...)
 }
 
 // AddSelection adds the specified Selection object's nodes to those in the
 // current selection and returns a new Selection object.
+// Nodes ordering in the result collection follows the same rules as .Add().
 func (s *Selection) AddSelection(sel *Selection) *Selection {
 	if sel == nil {
 		return s.AddNodes()
@@ -35,7 +42,7 @@ func (s *Selection) Union(sel *Selection) *Selection {
 // AddNodes adds the specified nodes to those in the
 // current selection and returns a new Selection object.
 func (s *Selection) AddNodes(nodes ...*html.Node) *Selection {
-	return pushStack(s, appendWithoutDuplicates(s.Nodes, nodes, nil))
+	return pushStack(s, sortWithoutDuplicates(s.Nodes, nodes, nil))
 }
 
 // AndSelf adds the previous set of elements on the stack to the current set.

--- a/expand_test.go
+++ b/expand_test.go
@@ -116,3 +116,13 @@ func TestAddBackFilteredRollback(t *testing.T) {
 	sel2 := sel.Find("h1").AddBackFiltered(".footer").End().End()
 	assertEqual(t, sel, sel2)
 }
+
+func TestAddOrdering(t *testing.T) {
+	sel := Doc().Find("h1").Add("h4").Add("p")
+	assertData(t, sel.Nodes[0].Data, "h1")
+	assertData(t, sel.Nodes[1].Data, "p")
+	assertData(t, sel.Nodes[2].Data, "h4")
+	assertData(t, sel.Nodes[3].Data, "p")
+	assertData(t, sel.Nodes[4].Data, "p")
+	assertData(t, sel.Nodes[5].Data, "p")
+}

--- a/type_test.go
+++ b/type_test.go
@@ -87,6 +87,12 @@ func assertEqual(t *testing.T, s1 *Selection, s2 *Selection) {
 	}
 }
 
+func assertData(t *testing.T, s1, s2 string) {
+	if s1 != s2 {
+		t.Error("Expected node data to be the same.")
+	}
+}
+
 func assertSelectionIs(t *testing.T, sel *Selection, is ...string) {
 	for i := 0; i < sel.Length(); i++ {
 		if !sel.Eq(i).Is(is[i]) {

--- a/utilities.go
+++ b/utilities.go
@@ -166,18 +166,24 @@ func sortWithoutDuplicates(target []*html.Node, nodes []*html.Node, targetSet ma
 	return uniqueSort(appendWithoutDuplicates(target, nodes, targetSet))
 }
 
-func uniqueSort(nodes []*html.Node) []*html.Node {
-	sort.SliceStable(nodes, func(i, j int) bool {
-		relative := compareDocumentPosition(nodes[i], nodes[j])
-		if (relative & PRECEDING) != 0 {
-			return true
-		} else if (relative & FOLLOWING) != 0 {
-			return false
-		}
+// NodeSlice is slice of Nodes used for sorting nodes.
+type NodeSlice []*html.Node
 
+func (ns NodeSlice) Len() int      { return len(ns) }
+func (ns NodeSlice) Swap(i, j int) { ns[i], ns[j] = ns[j], ns[i] }
+func (ns NodeSlice) Less(i, j int) bool {
+	relative := compareDocumentPosition(ns[i], ns[j])
+	if (relative & PRECEDING) != 0 {
 		return true
-	})
+	} else if (relative & FOLLOWING) != 0 {
+		return false
+	}
 
+	return true
+}
+
+func uniqueSort(nodes []*html.Node) []*html.Node {
+	sort.Sort(NodeSlice(nodes))
 	return nodes
 }
 

--- a/utilities.go
+++ b/utilities.go
@@ -158,7 +158,7 @@ func appendWithoutDuplicates(target []*html.Node, nodes []*html.Node, targetSet 
 }
 
 func sortWithoutDuplicates(target []*html.Node, nodes []*html.Node, targetSet map[*html.Node]bool) []*html.Node {
-	// If there are no nodes to add in, keep the target nodes (odering) untouched
+	// If there are no nodes to add in, keep the target nodes (ordering) untouched
 	if len(nodes) == 0 {
 		return target
 	}


### PR DESCRIPTION
And this applies to all other `.Add{...}` functions that call `.AddNodes()`.