### PR TITLE
Convert int to string using fmt.Sprintf

### DIFF
--- a/bench_iteration_test.go
+++ b/bench_iteration_test.go
@@ -1,6 +1,7 @@
 package goquery
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -31,7 +32,7 @@ func BenchmarkMap(b *testing.B) {
 	sel := DocW().Find("td")
 	f := func(i int, s *Selection) string {
 		tmp++
-		return string(tmp)
+		return fmt.Sprintf("%d", tmp)
 	}
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
See https://github.com/golang/go/issues/32479

Fix #341.

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>