### PR TITLE
Send context to parseHtml

### DIFF
--- a/manipulation_test.go
+++ b/manipulation_test.go
@@ -56,6 +56,13 @@ func TestAfterHtml(t *testing.T) {
 	printSel(t, doc.Selection)
 }
 
+func TestAfterHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr td").AfterHtml("<td>Test</td>")
+	assertLength(t, doc.Find("table tr td").Nodes, 14)
+	printSel(t, doc.Selection)
+}
+
 func TestAppend(t *testing.T) {
 	doc := Doc2Clone()
 	doc.Find("#main").Append("#nf6")
@@ -113,6 +120,15 @@ func TestAppendHtml(t *testing.T) {
 	printSel(t, doc.Selection)
 }
 
+func TestAppendHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr").AppendHtml("<td class='new-node'>new node</td>")
+
+	assertLength(t, doc.Find("table td").Nodes, 11)
+	assertLength(t, doc.Find("table tr td.new-node:last-child").Nodes, 4)
+	printSel(t, doc.Selection)
+}
+
 func TestBefore(t *testing.T) {
 	doc := Doc2Clone()
 	doc.Find("#main").Before("#nf6")
@@ -148,6 +164,14 @@ func TestBeforeHtml(t *testing.T) {
 	doc.Find("#main").BeforeHtml("<strong>new node</strong>")
 
 	assertLength(t, doc.Find("body > strong:first-child").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestBeforeHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr td:first-child").BeforeHtml("<td class='new-node'>new node</td>")
+
+	assertLength(t, doc.Find("table td.new-node:first-child").Nodes, 3)
 	printSel(t, doc.Selection)
 }
 
@@ -218,6 +242,15 @@ func TestPrependHtml(t *testing.T) {
 	printSel(t, doc.Selection)
 }
 
+func TestPrependHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr").PrependHtml("<td class='new-node'>new node</td>")
+
+	assertLength(t, doc.Find("table td").Nodes, 11)
+	assertLength(t, doc.Find("table tr td.new-node:first-child").Nodes, 4)
+	printSel(t, doc.Selection)
+}
+
 func TestRemove(t *testing.T) {
 	doc := Doc2Clone()
 	doc.Find("#nf1").Remove()
@@ -278,6 +311,15 @@ func TestReplaceWithHtml(t *testing.T) {
 	printSel(t, doc.Selection)
 }
 
+func TestReplaceWithHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table th").ReplaceWithHtml("<td>Test</td><td>Replace</td>")
+
+	assertLength(t, doc.Find("table th").Nodes, 0)
+	assertLength(t, doc.Find("table tr:first-child td").Nodes, 6)
+	printSel(t, doc.Selection)
+}
+
 func TestSetHtml(t *testing.T) {
 	doc := Doc2Clone()
 	q := doc.Find("#main, #foot")
@@ -310,6 +352,15 @@ func TestSetHtmlEmpty(t *testing.T) {
 
 	assertLength(t, doc.Find("#main").Nodes, 1)
 	assertLength(t, doc.Find("#main").Children().Nodes, 0)
+	printSel(t, doc.Selection)
+}
+
+func TestSetHtmlContext(t *testing.T) {
+	doc := DocBClone()
+	doc.Find("table tr").SetHtml("<td class='new-node'>Test</td>")
+
+	assertLength(t, doc.Find("table th").Nodes, 0)
+	assertLength(t, doc.Find("table td.new-node").Nodes, 4)
 	printSel(t, doc.Selection)
 }
 

--- a/type_test.go
+++ b/type_test.go
@@ -53,10 +53,6 @@ func DocB() *Document {
 	return docB
 }
 
-func DocBClone() *Document {
-	return CloneDocument(DocB())
-}
-
 func DocW() *Document {
 	if docW == nil {
 		docW = loadDoc("gowiki.html")
@@ -123,6 +119,14 @@ func loadDoc(page string) *Document {
 		panic(e.Error())
 	}
 	return NewDocumentFromNode(node)
+}
+
+func loadString(doc string, t *testing.T) *Document {
+	d, err := NewDocumentFromReader(strings.NewReader(doc))
+	if err != nil {
+		t.Error("Failed to parse test document")
+	}
+	return d
 }
 
 func TestNewDocument(t *testing.T) {

--- a/type_test.go
+++ b/type_test.go
@@ -53,6 +53,10 @@ func DocB() *Document {
 	return docB
 }
 
+func DocBClone() *Document {
+	return CloneDocument(DocB())
+}
+
 func DocW() *Document {
 	if docW == nil {
 		docW = loadDoc("gowiki.html")

--- a/utilities.go
+++ b/utilities.go
@@ -36,12 +36,22 @@ func NodeName(s *Selection) string {
 	if s.Length() == 0 {
 		return ""
 	}
-	switch n := s.Get(0); n.Type {
+	return nodeName(s.Get(0))
+}
+
+// nodeName returns the node name of the given html node.
+// See NodeName for additional details on behaviour.
+func nodeName(node *html.Node) string {
+	if node == nil {
+		return ""
+	}
+
+	switch node.Type {
 	case html.ElementNode, html.DoctypeNode:
-		return n.Data
+		return node.Data
 	default:
-		if n.Type >= 0 && int(n.Type) < len(nodeNames) {
-			return nodeNames[n.Type]
+		if node.Type >= 0 && int(node.Type) < len(nodeNames) {
+			return nodeNames[node.Type]
 		}
 		return ""
 	}


### PR DESCRIPTION
I stumbled upon the open bug in #178 and the open pull request to fix it in #235.
The original pull request seems to have been abandoned by its original creator, however I would like to have the original bug fixed.

This pr is a fork of the original one by @davidjwilkins and I have tried to address all the issues from the initial code review.

This is my first contribution to a go library so please let me know if I violated any conventions.
Let me know if you need any changes, or further documentation.

Original pr message for context:
```
This creates a new function parseHtmlWithContext, which behaves just like parseHtml but takes an *html.Node as context.

It also create a function eachNodeHtml which will iterate over each node in a selection, check to see if we have parsed html for this node type already, and if not, will call parseHtmlWithContext with either the current node, or it's parent, depending on whether you passed parent as true or false.

It also changes AfterHtml, AppendHtml, BeforeHtml, PrependHtml, ReplaceWithHtml, SetHtml, WrapHtml, WrapAllHtml, and WrapInnerHtml to use one or both of these functions.

New tests were added for all except the WrapHtml* functions - changing these functions may have been unncessary - I couldn't think of a way to test this - Go automatically wraps tr elements in tbody, so I can't wrap those, and I can't think of any other situation that this would occur in.
```