### PR TITLE
Issue when parseHtmlWithContext is being called.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # goquery - a little like that j-thing, only in Go
-[![build status](https://secure.travis-ci.org/PuerkitoBio/goquery.svg?branch=master)](http://travis-ci.org/PuerkitoBio/goquery) [![GoDoc](https://godoc.org/github.com/PuerkitoBio/goquery?status.png)](http://godoc.org/github.com/PuerkitoBio/goquery) [![Sourcegraph Badge](https://sourcegraph.com/github.com/PuerkitoBio/goquery/-/badge.svg)](https://sourcegraph.com/github.com/PuerkitoBio/goquery?badge)
+[![build status](https://secure.travis-ci.org/PuerkitoBio/goquery.svg?branch=master)](http://travis-ci.org/PuerkitoBio/goquery) [![GoDoc](https://godoc.org/github.com/fresh8/goquery?status.png)](http://godoc.org/github.com/fresh8/goquery) [![Sourcegraph Badge](https://sourcegraph.com/github.com/fresh8/goquery/-/badge.svg)](https://sourcegraph.com/github.com/fresh8/goquery?badge)
 
 goquery brings a syntax and a set of features similar to [jQuery][] to the [Go language][go]. It is based on Go's [net/html package][html] and the CSS Selector library [cascadia][]. Since the net/html parser returns nodes, and not a full-featured DOM tree, jQuery's stateful manipulation functions (like height(), css(), detach()) have been left off.
 
@@ -21,16 +21,16 @@ Syntax-wise, it is as close as possible to jQuery, with the same function names 
 
 Please note that because of the net/html dependency, goquery requires Go1.1+.
 
-    $ go get github.com/PuerkitoBio/goquery
+    $ go get github.com/fresh8/goquery
 
 (optional) To run unit tests:
 
-    $ cd $GOPATH/src/github.com/PuerkitoBio/goquery
+    $ cd $GOPATH/src/github.com/fresh8/goquery
     $ go test
 
 (optional) To run benchmarks (warning: it runs for a few minutes):
 
-    $ cd $GOPATH/src/github.com/PuerkitoBio/goquery
+    $ cd $GOPATH/src/github.com/fresh8/goquery
     $ go test -bench=".*"
 
 ## Changelog
@@ -101,7 +101,7 @@ import (
   "log"
   "net/http"
 
-  "github.com/PuerkitoBio/goquery"
+  "github.com/fresh8/goquery"
 )
 
 func ExampleScrape() {
@@ -176,11 +176,11 @@ The [BSD 3-Clause license][bsd], the same as the [Go language][golic]. Cascadia'
 [bsd]: http://opensource.org/licenses/BSD-3-Clause
 [golic]: http://golang.org/LICENSE
 [caslic]: https://github.com/andybalholm/cascadia/blob/master/LICENSE
-[doc]: http://godoc.org/github.com/PuerkitoBio/goquery
+[doc]: http://godoc.org/github.com/fresh8/goquery
 [index]: http://api.jquery.com/index/
 [gonet]: https://github.com/golang/net/
 [html]: http://godoc.org/golang.org/x/net/html
-[wiki]: https://github.com/PuerkitoBio/goquery/wiki/Tips-and-tricks
+[wiki]: https://github.com/fresh8/goquery/wiki/Tips-and-tricks
 [thatguystone]: https://github.com/thatguystone
 [piotr]: https://github.com/piotrkowalczuk
 [goq]: https://github.com/andrewstuart/goq

--- a/bench/v0.1.0
+++ b/bench/v0.1.0
@@ -433,4 +433,4 @@ BenchmarkPrevFilteredUntilNodes	   10000	    150584 ns/op
 	bench_traversal_test.go:665: PrevFilteredUntilNodes=20
 	bench_traversal_test.go:665: PrevFilteredUntilNodes=20
 	bench_traversal_test.go:665: PrevFilteredUntilNodes=20
-ok  	github.com/PuerkitoBio/goquery	188.326s
+ok  	github.com/fresh8/goquery	188.326s

--- a/bench/v0.1.1
+++ b/bench/v0.1.1
@@ -435,4 +435,4 @@ BenchmarkPrevFilteredUntilNodes	   10000	    107495 ns/op
 	bench_traversal_test.go:665: PrevFilteredUntilNodes=20
 	bench_traversal_test.go:665: PrevFilteredUntilNodes=20
 	bench_traversal_test.go:665: PrevFilteredUntilNodes=20
-ok  	github.com/PuerkitoBio/goquery	187.652s
+ok  	github.com/fresh8/goquery	187.652s

--- a/bench/v0.2.0
+++ b/bench/v0.2.0
@@ -456,4 +456,4 @@ bench_traversal_test.go:715: 	ClosestNodes=2
 bench_traversal_test.go:715: 	ClosestNodes=2
 bench_traversal_test.go:715: 	ClosestNodes=2
 bench_traversal_test.go:715: 	ClosestNodes=2
-ok  	github.com/PuerkitoBio/goquery	192.541s
+ok  	github.com/fresh8/goquery	192.541s

--- a/bench/v0.2.1-go1.1rc1
+++ b/bench/v0.2.1-go1.1rc1
@@ -467,4 +467,4 @@ BenchmarkClosestNodes	 5000000	       733 ns/op
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
-ok  	github.com/PuerkitoBio/goquery	220.793s
+ok  	github.com/fresh8/goquery	220.793s

--- a/bench/v0.3.0
+++ b/bench/v0.3.0
@@ -473,4 +473,4 @@ BenchmarkClosestNodes	 5000000	       737 ns/op
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
-ok  	github.com/PuerkitoBio/goquery	224.003s
+ok  	github.com/fresh8/goquery	224.003s

--- a/bench/v0.3.2-go1.2
+++ b/bench/v0.3.2-go1.2
@@ -475,4 +475,4 @@ BenchmarkClosestNodes	 5000000	       617 ns/op
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
-ok  	github.com/PuerkitoBio/goquery	218.724s
+ok  	github.com/fresh8/goquery	218.724s

--- a/bench/v0.3.2-go1.2-take2
+++ b/bench/v0.3.2-go1.2-take2
@@ -474,4 +474,4 @@ BenchmarkClosestNodes	 5000000	       663 ns/op
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
-ok  	github.com/PuerkitoBio/goquery	218.007s
+ok  	github.com/fresh8/goquery	218.007s

--- a/bench/v0.3.2-go1.2rc1
+++ b/bench/v0.3.2-go1.2rc1
@@ -474,4 +474,4 @@ BenchmarkClosestNodes	 5000000	       627 ns/op
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
 	bench_traversal_test.go:715: ClosestNodes=2
-ok  	github.com/PuerkitoBio/goquery	215.785s
+ok  	github.com/fresh8/goquery	215.785s

--- a/bench/v1.0.0-go1.7
+++ b/bench/v1.0.0-go1.7
@@ -82,4 +82,4 @@ BenchmarkClosest-4                         	  500000	      3310 ns/op	     160 B
 BenchmarkClosestSelection-4                	 5000000	       361 ns/op	      96 B/op	       6 allocs/op
 BenchmarkClosestNodes-4                    	 5000000	       359 ns/op	      96 B/op	       6 allocs/op
 PASS
-ok  	github.com/PuerkitoBio/goquery	163.718s
+ok  	github.com/fresh8/goquery	163.718s

--- a/bench/v1.0.1a-go1.7
+++ b/bench/v1.0.1a-go1.7
@@ -82,4 +82,4 @@ BenchmarkClosest-4                         	  500000	      4065 ns/op	     160 B
 BenchmarkClosestSelection-4                	 2000000	       756 ns/op	      96 B/op	       6 allocs/op
 BenchmarkClosestNodes-4                    	 2000000	       753 ns/op	      96 B/op	       6 allocs/op
 PASS
-ok  	github.com/PuerkitoBio/goquery	162.053s
+ok  	github.com/fresh8/goquery	162.053s

--- a/bench/v1.0.1b-go1.7
+++ b/bench/v1.0.1b-go1.7
@@ -82,4 +82,4 @@ BenchmarkClosest-4                         	  500000	      3448 ns/op	     160 B
 BenchmarkClosestSelection-4                	 3000000	       528 ns/op	      96 B/op	       6 allocs/op
 BenchmarkClosestNodes-4                    	 3000000	       523 ns/op	      96 B/op	       6 allocs/op
 PASS
-ok  	github.com/PuerkitoBio/goquery	162.012s
+ok  	github.com/fresh8/goquery	162.012s

--- a/bench/v1.0.1c-go1.7
+++ b/bench/v1.0.1c-go1.7
@@ -83,4 +83,4 @@ BenchmarkClosest-4                         	  500000	      3480 ns/op	     160 B
 BenchmarkClosestSelection-4                	 2000000	       722 ns/op	      96 B/op	       6 allocs/op
 BenchmarkClosestNodes-4                    	 2000000	       719 ns/op	      96 B/op	       6 allocs/op
 PASS
-ok  	github.com/PuerkitoBio/goquery	160.565s
+ok  	github.com/fresh8/goquery	160.565s

--- a/doc.go
+++ b/doc.go
@@ -43,7 +43,7 @@ Go's fmt package), even though some of its methods are less than intuitive (look
 at you, index()...).
 
 It is hosted on GitHub, along with additional documentation in the README.md
-file: https://github.com/puerkitobio/goquery
+file: https://github.com/fresh8/goquery
 
 Please note that because of the net/html dependency, goquery requires Go1.1+.
 

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/PuerkitoBio/goquery"
+	"github.com/fresh8/goquery"
 )
 
 // This example scrapes the reviews shown on the home page of metalsucks.net.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/PuerkitoBio/goquery
+module github.com/fresh8/goquery
+
+go 1.15
 
 require (
-	github.com/andybalholm/cascadia v1.1.0
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+	github.com/andybalholm/cascadia v1.2.0
+	golang.org/x/net v0.0.0-20201224014010-6772e930b67b
 )
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,9 @@
-github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
-github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+github.com/andybalholm/cascadia v1.2.0 h1:vuRCkM5Ozh/BfmsaTm26kbjm0mIOM3yS5Ek/F5h18aE=
+github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/net v0.0.0-20201224014010-6772e930b67b h1:iFwSg7t5GZmB/Q5TjiEAsdoLDrdJRC1RiF2WhuV29Qw=
+golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/manipulation.go
+++ b/manipulation.go
@@ -572,6 +572,12 @@ func parseHtml(h string) []*html.Node {
 }
 
 func parseHtmlWithContext(h string, context *html.Node) []*html.Node {
+
+	// Avoid issue where h is <p></p> and a panic is thrown
+	if context != nil && context.Type != html.ElementNode {
+		return []*html.Node{context}
+	}
+
 	// Errors are only returned when the io.Reader returns any error besides
 	// EOF, but strings.Reader never will
 	nodes, err := html.ParseFragment(strings.NewReader(h), context)

--- a/manipulation_test.go
+++ b/manipulation_test.go
@@ -2,6 +2,8 @@ package goquery
 
 import (
 	"testing"
+
+	"golang.org/x/net/html"
 )
 
 const (
@@ -688,4 +690,23 @@ func TestParsingRespectsVaryingContext(t *testing.T) {
 			oA,
 			oBothA)
 	}
+}
+
+func TestParseHtmlWithContext(t *testing.T) {
+	h := "<p></p>"
+	context := &html.Node{
+		Type: html.TextNode,
+		Data: "<p></p>",
+	}
+	out := []*html.Node{context}
+	res := parseHtmlWithContext(h, context)
+	if len(out) != 1 && len(res) != 1 {
+		t.Errorf("Expected results to only have one entry")
+	}
+
+	if out[0] != res[0] {
+		t.Errorf("Expected values to be the same %v, %v",
+			out[0], res[0])
+	}
+
 }


### PR DESCRIPTION
Noticed a problem when using this package with advancedlogic/goose, a specific page was throwing a panic runtime error.

I changed the vendored code to log the page and context and noticed that a non ElementNode was being passed:
`panic(fmt.Sprintf("goquery: failed to parse HTML: %v , page: %v, context: %v", err, h, context))`

```
goquery: failed to parse HTML: html: ParseFragment of non-element Node , page: <p></p>, context: &{0xc000486460 0xc000487490 0xc000487f10 0xc0004873b0 0xc000487f80 1 span  <p></p>    []}
goroutine 68 [running]:
net/http.(*conn).serve.func1(0xc000798e60)
	/usr/local/opt/go/libexec/src/net/http/server.go:1801 +0x147
panic(0x18fe3c0, 0xc00489da50)
	/usr/local/opt/go/libexec/src/runtime/panic.go:975 +0x47a
github.com/PuerkitoBio/goquery.parseHtmlWithContext(0xc004822dc0, 0x9e, 0xc000487420, 0x5, 0x2271140, 0x0)
	.../vendor/github.com/PuerkitoBio/goquery/manipulation.go:585 +0x1df
github.com/PuerkitoBio/goquery.(*Selection).eachNodeHtml(0xc001478c60, 0xc004822dc0, 0x9e, 0x1, 0x1ab5088, 0x9e)
	.../vendor/github.com/PuerkitoBio/goquery/manipulation.go:675 +0x1d0
github.com/PuerkitoBio/goquery.(*Selection).BeforeHtml(0xc001478c60, 0xc004822dc0, 0x9e, 0xc004822d20)
	.../vendor/github.com/PuerkitoBio/goquery/manipulation.go:139 +0x50
github.com/advancedlogic/GoOse.(*Cleaner).convertDivsToParagraphs.func1(0x1, 0xc001478900)
	.../vendor/github.com/advancedlogic/GoOse/cleaner.go:553 +0x298
```

Not sure why goose passes a non html.ElementNode to this function, but the panic is not great.

Added a test case for this.

I'm not sure this is the correct fix as it's not clear why parseHtmlWithContext is being called for a non element node.

But creating the PR incase someone else runs into this problem.
