### PR TITLE
Fixed ExampleScrape README Sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,11 @@ func ExampleScrape() {
   }
 
   // Find the review items
-  doc.Find(".sidebar-reviews article .content-block").Each(func(i int, s *goquery.Selection) {
-    // For each item found, get the band and title
-    band := s.Find("a").Text()
-    title := s.Find("i").Text()
-    fmt.Printf("Review %d: %s - %s\n", i, band, title)
-  })
+  doc.Find(".left-content article .post-title").Each(func(i int, s *goquery.Selection) {
+		// For each item found, get the title
+		title := s.Find("a").Text()
+		fmt.Printf("Review %d: %s\n", i, title)
+	})
 }
 
 func main() {


### PR DESCRIPTION
Changed the README `ExampleScrape() ` example slightly which now works with [metalsucks.net](http://metalsucks.net). Below is the output.

![image](https://user-images.githubusercontent.com/24381727/120848483-85204300-c57d-11eb-84fc-f52c6e98a2a0.png)
