### PR TITLE
Add GetSingleSelectionList

### DIFF
--- a/iteration.go
+++ b/iteration.go
@@ -37,3 +37,13 @@ func (s *Selection) Map(f func(int, *Selection) string) (result []string) {
 
 	return result
 }
+
+// GetSingleSelectionList iterates over a Selection object and returns all
+// matched elements as a slice of single-element Selection.
+func (s *Selection) GetSingleSelectionList() []*Selection {
+	list := make([]*Selection, len(s.Nodes))
+	for i, n := range s.Nodes {
+		list[i] = newSingleSelection(n, s.document)
+	}
+	return list
+}

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -86,3 +86,29 @@ func TestForRange(t *testing.T) {
 		t.Errorf("expected initial selection to still have length %d, got %d", initLen, sel.Length())
 	}
 }
+
+func TestGetSingleSelectionList(t *testing.T) {
+	expectedValues := []string{"n1", "n2", "n3", "n4", "n5", "n6"}
+
+	sel := Doc2().Find("#main div")
+	result := sel.GetSingleSelectionList()
+
+	if len(result) != 6 {
+		t.Errorf("Expected GetSingleSelectionList result to have a length of 6, found %v.", len(result))
+	} else {
+		for i, s := range result {
+			if s.Length() != 1 {
+				t.Errorf("Expected result[%d] to contain only one selected element, got %d", i, s.Length())
+			}
+
+			value, exists := s.Attr("id")
+			if exists == false {
+				t.Fatalf("Expected result[%d]'s node to have \"id\" attribute", i)
+			}
+
+			if value != expectedValues[i] {
+				t.Errorf("Expected result[%d]'s node \"id\" attribute to be %q", i, expectedValues[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Sometimes I encounter scenarios where `Each` method is insufficient, for example when I need to return an error during the iteration. One of first things I tried was looping through `selection.Nodes`, but working with that brings it's own issues as far I remember. So, I ended up doing this:
```go
func GetSingleSelectionList(selection *goquery.Selection) []*goquery.Selection {
	selectionList := make([]*goquery.Selection, selection.Length())
	selection.Each(func (i int, sel *goquery.Selection) {
		selectionList[i] = sel
	})
	return selectionList
}
```
This feels like doing something that should be built in though.

This is where this PR comes in. I am not sure how to name this method though - for now it's `GetSingleSelectionList`, unless it conflicts with existing naming. Maybe something with `split` or `spread` wording would fit better, or go other direction and make it more accessible.