### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Syntax-wise, it is as close as possible to jQuery, with the same function names 
 
 Please note that because of the net/html dependency, goquery requires Go1.1+ and is tested on Go1.7+.
 
-    $ go get github.com/PuerkitoBio/goquery
+    $ go install github.com/PuerkitoBio/goquery@latest
 
 (optional) To run unit tests:
 


### PR DESCRIPTION
Otherwise new comers who want to follow along would see something like this:
        'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.