### PR TITLE
Pre-allocate slice in generic Map function

### DIFF
--- a/iteration.go
+++ b/iteration.go
@@ -37,8 +37,10 @@ func (s *Selection) Map(f func(int, *Selection) string) (result []string) {
 // Map is the generic version of Selection.Map, allowing any type to be
 // returned.
 func Map[E any](s *Selection, f func(int, *Selection) E) (result []E) {
+	result = make([]E, len(s.Nodes))
+
 	for i, n := range s.Nodes {
-		result = append(result, f(i, newSingleSelection(n, s.document)))
+		result[i] = f(i, newSingleSelection(n, s.document))
 	}
 
 	return result


### PR DESCRIPTION
Hey!
Thanks for this great library, really helped me out with some scraping!

I noticed that the generic `Map` function just added the other week always `append`s, growing the slice as needed instead of pre-allocating it upfront.

Benchmark results from my M1:
```
Without pre-allocation:
BenchmarkMap-10                              	  238780	      5140 ns/op

With pre-allocation:
BenchmarkMap-10                              	  277968	      4317 ns/op
```

If you think it's not worth it, no hard feelings. Just thought it would be a fun, easy, optimization to make.