### PR TITLE
Bump GitHub workflows to their latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  # Enable version updates for GitHub action workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         run: go test ./... -v -cover

--- a/README.md
+++ b/README.md
@@ -184,15 +184,15 @@ There are a number of ways you can support the project:
 
 The [BSD 3-Clause license][bsd], the same as the [Go language][golic]. Cascadia's license is [here][caslic].
 
-[jquery]: http://jquery.com/
-[go]: http://golang.org/
+[jquery]: https://jquery.com/
+[go]: https://go.dev/
 [cascadia]: https://github.com/andybalholm/cascadia
 [cascadiacli]: https://github.com/suntong/cascadia
-[bsd]: http://opensource.org/licenses/BSD-3-Clause
-[golic]: http://golang.org/LICENSE
+[bsd]: https://opensource.org/licenses/BSD-3-Clause
+[golic]: https://go.dev/LICENSE
 [caslic]: https://github.com/andybalholm/cascadia/blob/master/LICENSE
 [doc]: https://pkg.go.dev/github.com/PuerkitoBio/goquery
-[index]: http://api.jquery.com/index/
+[index]: https://api.jquery.com/index/
 [gonet]: https://github.com/golang/net/
 [html]: https://pkg.go.dev/golang.org/x/net/html
 [wiki]: https://github.com/PuerkitoBio/goquery/wiki/Tips-and-tricks

--- a/expand.go
+++ b/expand.go
@@ -62,7 +62,7 @@ func (s *Selection) AddBackFiltered(selector string) *Selection {
 }
 
 // AddBackMatcher reduces the previous set of elements on the stack to those that match
-// the mateher, and adds them to the curernt set.
+// the matcher, and adds them to the current set.
 // It returns a new Selection object containing the current Selection combined
 // with the filtered previous one
 func (s *Selection) AddBackMatcher(m Matcher) *Selection {


### PR DESCRIPTION
This PR bumps GitHub workflows to their latest versions, thus avoiding deprecation warnings as seen [here](https://github.com/PuerkitoBio/goquery/actions/runs/9439105361).