### PR TITLE
Support IterEach based on 1.23 Iterator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x, 1.23rc2]
+        go-version: [1.21.x, 1.22.x, 1.23.0-rc.2]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x, 1.23.0-rc.1]
+        go-version: [1.21.x, 1.22.x, 1.23rc2]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x, 1.23.0-rc.1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/bench_iteration123_test.go
+++ b/bench_iteration123_test.go
@@ -1,0 +1,48 @@
+//go:build go1.23
+// +build go1.23
+
+package goquery
+
+import "testing"
+
+func BenchmarkEachIter123(b *testing.B) {
+	var tmp, n int
+
+	b.StopTimer()
+	sel := DocW().Find("td")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		for range sel.EachIter() {
+			tmp++
+		}
+		if n == 0 {
+			n = tmp
+		}
+	}
+	if n != 59 {
+		b.Fatalf("want 59, got %d", n)
+	}
+}
+
+func BenchmarkEachIterWithBreak123(b *testing.B) {
+	var tmp, n int
+
+	b.StopTimer()
+	sel := DocW().Find("td")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tmp = 0
+		for range sel.EachIter() {
+			tmp++
+			if tmp >= 10 {
+				break
+			}
+		}
+		if n == 0 {
+			n = tmp
+		}
+	}
+	if n != 10 {
+		b.Fatalf("want 10, got %d", n)
+	}
+}

--- a/bench_iteration_test.go
+++ b/bench_iteration_test.go
@@ -25,6 +25,48 @@ func BenchmarkEach(b *testing.B) {
 	}
 }
 
+func BenchmarkEachIter(b *testing.B) {
+	var tmp, n int
+
+	b.StopTimer()
+	sel := DocW().Find("td")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		for range sel.EachIter() {
+			tmp++
+		}
+		if n == 0 {
+			n = tmp
+		}
+	}
+	if n != 59 {
+		b.Fatalf("want 59, got %d", n)
+	}
+}
+
+func BenchmarkEachIterWithBreak(b *testing.B) {
+	var tmp, n int
+
+	b.StopTimer()
+	sel := DocW().Find("td")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tmp = 0
+		for range sel.EachIter() {
+			tmp++
+			if tmp >= 10 {
+				break
+			}
+		}
+		if n == 0 {
+			n = tmp
+		}
+	}
+	if n != 10 {
+		b.Fatalf("want 10, got %d", n)
+	}
+}
+
 func BenchmarkMap(b *testing.B) {
 	var tmp, n int
 

--- a/bench_iteration_test.go
+++ b/bench_iteration_test.go
@@ -32,9 +32,10 @@ func BenchmarkEachIter(b *testing.B) {
 	sel := DocW().Find("td")
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		for range sel.EachIter() {
+		sel.EachIter()(func(i int, s *Selection) bool {
 			tmp++
-		}
+			return true
+		})
 		if n == 0 {
 			n = tmp
 		}
@@ -52,12 +53,11 @@ func BenchmarkEachIterWithBreak(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		tmp = 0
-		for range sel.EachIter() {
+		sel.EachIter()(func(i int, s *Selection) bool {
 			tmp++
-			if tmp >= 10 {
-				break
-			}
-		}
+			return tmp < 10
+		})
+
 		if n == 0 {
 			n = tmp
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ require (
 	golang.org/x/net v0.27.0
 )
 
-go 1.18
+go 1.23

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ require (
 	golang.org/x/net v0.27.0
 )
 
-go 1.23
+go 1.18

--- a/iteration.go
+++ b/iteration.go
@@ -1,5 +1,7 @@
 package goquery
 
+import "iter"
+
 // Each iterates over a Selection object, executing a function for each
 // matched element. It returns the current Selection object. The function
 // f is called for each element in the selection with the index of the
@@ -10,6 +12,18 @@ func (s *Selection) Each(f func(int, *Selection)) *Selection {
 		f(i, newSingleSelection(n, s.document))
 	}
 	return s
+}
+
+// EachIter returns an iterator that yields the Selection object in order.
+// The implementation is similar to Each, but it returns an iterator instead.
+func (s *Selection) EachIter() iter.Seq2[int, *Selection] {
+	return func(yield func(int, *Selection) bool) {
+		for i, n := range s.Nodes {
+			if !yield(i, newSingleSelection(n, s.document)) {
+				return
+			}
+		}
+	}
 }
 
 // EachWithBreak iterates over a Selection object, executing a function for each

--- a/iteration.go
+++ b/iteration.go
@@ -1,7 +1,5 @@
 package goquery
 
-import "iter"
-
 // Each iterates over a Selection object, executing a function for each
 // matched element. It returns the current Selection object. The function
 // f is called for each element in the selection with the index of the
@@ -16,7 +14,7 @@ func (s *Selection) Each(f func(int, *Selection)) *Selection {
 
 // EachIter returns an iterator that yields the Selection object in order.
 // The implementation is similar to Each, but it returns an iterator instead.
-func (s *Selection) EachIter() iter.Seq2[int, *Selection] {
+func (s *Selection) EachIter() func(yield func(int, *Selection) bool) {
 	return func(yield func(int, *Selection) bool) {
 		for i, n := range s.Nodes {
 			if !yield(i, newSingleSelection(n, s.document)) {

--- a/iteration123_test.go
+++ b/iteration123_test.go
@@ -1,0 +1,42 @@
+//go:build go1.23
+// +build go1.23
+
+package goquery
+
+import "testing"
+
+func TestEachIter123(t *testing.T) {
+	var cnt int
+
+	sel := Doc().Find(".hero-unit .row-fluid")
+
+	for i, s := range sel.EachIter() {
+		cnt++
+		t.Logf("At index %v, node %v", i, s.Nodes[0].Data)
+	}
+
+	sel = sel.Find("a")
+
+	if cnt != 4 {
+		t.Errorf("Expected EachIter() to call function 4 times, got %v times.", cnt)
+	}
+	assertLength(t, sel.Nodes, 6)
+}
+
+func TestEachIterWithBreak123(t *testing.T) {
+	var cnt int
+
+	sel := Doc().Find(".hero-unit .row-fluid")
+	for i, s := range sel.EachIter() {
+		cnt++
+		t.Logf("At index %v, node %v", i, s.Nodes[0].Data)
+		break
+	}
+
+	sel = sel.Find("a")
+
+	if cnt != 1 {
+		t.Errorf("Expected EachIter() to call function 1 time, got %v times.", cnt)
+	}
+	assertLength(t, sel.Nodes, 6)
+}

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -105,3 +105,39 @@ func TestGenericMap(t *testing.T) {
 		t.Errorf("Expected Map array result to have a length of 3, found %v.", len(vals))
 	}
 }
+
+func TestEachIter(t *testing.T) {
+	var cnt int
+
+	sel := Doc().Find(".hero-unit .row-fluid")
+
+	for i, s := range sel.EachIter() {
+		cnt++
+		t.Logf("At index %v, node %v", i, s.Nodes[0].Data)
+	}
+
+	sel = sel.Find("a")
+
+	if cnt != 4 {
+		t.Errorf("Expected Each() to call function 4 times, got %v times.", cnt)
+	}
+	assertLength(t, sel.Nodes, 6)
+}
+
+func TestEachIterWithBreak(t *testing.T) {
+	var cnt int
+
+	sel := Doc().Find(".hero-unit .row-fluid")
+	for i, s := range sel.EachIter() {
+		cnt++
+		t.Logf("At index %v, node %v", i, s.Nodes[0].Data)
+		break
+	}
+
+	sel = sel.Find("a")
+
+	if cnt != 1 {
+		t.Errorf("Expected Each() to call function 1 time, got %v times.", cnt)
+	}
+	assertLength(t, sel.Nodes, 6)
+}

--- a/iteration_test.go
+++ b/iteration_test.go
@@ -110,16 +110,15 @@ func TestEachIter(t *testing.T) {
 	var cnt int
 
 	sel := Doc().Find(".hero-unit .row-fluid")
-
-	for i, s := range sel.EachIter() {
+	sel.EachIter()(func(i int, n *Selection) bool {
 		cnt++
-		t.Logf("At index %v, node %v", i, s.Nodes[0].Data)
-	}
-
+		t.Logf("At index %v, node %v", i, n.Nodes[0].Data)
+		return true
+	})
 	sel = sel.Find("a")
 
 	if cnt != 4 {
-		t.Errorf("Expected Each() to call function 4 times, got %v times.", cnt)
+		t.Errorf("Expected EachIter() to call function 4 time, got %v times.", cnt)
 	}
 	assertLength(t, sel.Nodes, 6)
 }
@@ -128,16 +127,15 @@ func TestEachIterWithBreak(t *testing.T) {
 	var cnt int
 
 	sel := Doc().Find(".hero-unit .row-fluid")
-	for i, s := range sel.EachIter() {
+	sel.EachIter()(func(i int, n *Selection) bool {
 		cnt++
-		t.Logf("At index %v, node %v", i, s.Nodes[0].Data)
-		break
-	}
-
+		t.Logf("At index %v, node %v", i, n.Nodes[0].Data)
+		return false
+	})
 	sel = sel.Find("a")
 
 	if cnt != 1 {
-		t.Errorf("Expected Each() to call function 1 time, got %v times.", cnt)
+		t.Errorf("Expected EachIter() to call function 1 time, got %v times.", cnt)
 	}
 	assertLength(t, sel.Nodes, 6)
 }


### PR DESCRIPTION
Resolve #482

# What's change
- Bump to golang 1.23
- Support `IterEach`

Note: Considering that Go 1.23 is not stable yet, I am not sure if merging that PR would be risky.

# Detail

Test cases:
`TestEachIter` is similar with `TestEach`
`TestEachIterWithBreak` is similar with`TestEachWithBreak`

Benchmarks:
`BenchmarkEachIter` is similar with `BenchmarkEach`
`BenchmarkEachIterWithBreak` is similar with `BenchmarkEachWithBreak`
