### PR TITLE
Resolve WARNING in CI of github actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Test
         run: go test ./... -v -cover


### PR DESCRIPTION
Fixes: #486

I have already confirmed that WARNING has been resolved in the branch I forked.
https://github.com/Kiyo510/goquery/actions/runs/10352815872