### PR TITLE
Prepare for version v1.10.1 to fix GO-2024-3333 / CVE-2024-45338

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Ongoing goquery development is tested on the latest 2 versions of Go.
 
 **Note that goquery's API is now stable, and will not break.**
 
+*    **2024-12-26 (v1.10.1)** : Update `go.mod` dependencies.
 *    **2024-09-06 (v1.10.0)** : Add `EachIter` which provides an iterator that can be used in `for..range` loops on the `*Selection` object. **goquery now requires Go version 1.23+** (thanks [@amikai](https://github.com/amikai)).
 *    **2024-09-06 (v1.9.3)** : Update `go.mod` dependencies.
 *    **2024-04-29 (v1.9.2)** : Update `go.mod` dependencies.


### PR DESCRIPTION
Add changelog entry for 1.10.1.

Only dependencies update, however includes fixes for GO-2024-3333.

---

Hello folks!
With this PR I would like to request a possible "v1.10.1" tag (I think that once this PR is merged it will also need a corresponding `git tag` and/or feel free to incorporate this commit as you prefer!) so that GO-2024-3333 AKA CVE-2024-45338 is addressed.

That was fixed via commit 40758683ede28cb06df81b65faf2a6a8c75ac0e7.


Thank you!
