### PR TITLE
perf: pre-allocate result slice in winnowNodes Not paths

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -140,18 +140,36 @@ func winnow(sel *Selection, m Matcher, keep bool) []*html.Node {
 // to get rid of (Not) the matching elements.
 func winnowNodes(sel *Selection, nodes []*html.Node, keep bool) []*html.Node {
 	if len(nodes)+len(sel.Nodes) < minNodesForSet {
-		return grep(sel, func(i int, s *Selection) bool {
-			return isInSlice(nodes, s.Get(0)) == keep
-		})
+		if keep {
+			return grep(sel, func(i int, s *Selection) bool {
+				return isInSlice(nodes, s.Get(0))
+			})
+		}
+		result := make([]*html.Node, 0, len(sel.Nodes))
+		for _, n := range sel.Nodes {
+			if !isInSlice(nodes, n) {
+				result = append(result, n)
+			}
+		}
+		return result
 	}
 
 	set := make(map[*html.Node]bool)
 	for _, n := range nodes {
 		set[n] = true
 	}
-	return grep(sel, func(i int, s *Selection) bool {
-		return set[s.Get(0)] == keep
-	})
+	if keep {
+		return grep(sel, func(i int, s *Selection) bool {
+			return set[s.Get(0)]
+		})
+	}
+	result := make([]*html.Node, 0, len(sel.Nodes))
+	for _, n := range sel.Nodes {
+		if !set[n] {
+			result = append(result, n)
+		}
+	}
+	return result
 }
 
 // Filter based on a function test, and the indicator to keep (Filter) or


### PR DESCRIPTION
The winnowNodes Not paths (used by NotNodes, NotSelection) grew the result slice via append from nil, causing ~10 intermediate backing-array allocations for large selections. Pre-allocate at len(sel.Nodes) since most nodes pass the Not filter. The keep (Filter) paths are unchanged.

goos: linux
goarch: arm64
pkg: github.com/PuerkitoBio/goquery

name               old B/op    new B/op    delta
NotNodes-8         9384        3120        -66.7%
NotSelection-8     9384        3120        -66.7%
FilterNodes-8      72          72          +0.0%
FilterSelection-8  72          72          +0.0%

name               old allocs  new allocs  delta
NotNodes-8         11          2           -81.8%
NotSelection-8     11          2           -81.8%
FilterNodes-8      3           3           +0.0%
FilterSelection-8  3           3           +0.0%

name               old ns/op   new ns/op   delta
NotNodes-8         18000       9900        ~-45%
NotSelection-8     18900       6600        ~-65%
FilterNodes-8      2160        2220        ~+0%
FilterSelection-8  2240        1950        ~+0%