### PR TITLE
perf: replace Index() PrevAll traversal with direct sibling walk

### DIFF
--- a/array.go
+++ b/array.go
@@ -81,7 +81,13 @@ func (s *Selection) Get(index int) *html.Node {
 // relative to its sibling elements.
 func (s *Selection) Index() int {
 	if len(s.Nodes) > 0 {
-		return newSingleSelection(s.Nodes[0], s.document).PrevAll().Length()
+		i := 0
+		for n := s.Nodes[0].PrevSibling; n != nil; n = n.PrevSibling {
+			if n.Type == html.ElementNode {
+				i++
+			}
+		}
+		return i
 	}
 	return -1
 }


### PR DESCRIPTION
Index() was creating a Selection, calling PrevAll() which traversed through getSiblingNodes -> mapNodes (allocating a dedup map and intermediate slices), then calling Length() on the result.

This commit replaces this with a direct PrevSibling pointer walk that counts element nodes, bringing the number of allocations down to zero instead of a couple of hundreds on local benchmarks