### PR TITLE
perf: short-circuit IsFunction, IsSelection, and IsNodes

### DIFF
--- a/query.go
+++ b/query.go
@@ -24,19 +24,32 @@ func (s *Selection) IsMatcher(m Matcher) bool {
 // IsFunction checks the current matched set of elements against a predicate and
 // returns true if at least one of these elements matches.
 func (s *Selection) IsFunction(f func(int, *Selection) bool) bool {
-	return s.FilterFunction(f).Length() > 0
+	for i, n := range s.Nodes {
+		if f(i, newSingleSelection(n, s.document)) {
+			return true
+		}
+	}
+	return false
 }
 
 // IsSelection checks the current matched set of elements against a Selection object
 // and returns true if at least one of these elements matches.
 func (s *Selection) IsSelection(sel *Selection) bool {
-	return s.FilterSelection(sel).Length() > 0
+	if sel == nil {
+		return false
+	}
+	return s.IsNodes(sel.Nodes...)
 }
 
 // IsNodes checks the current matched set of elements against the specified nodes
 // and returns true if at least one of these elements matches.
 func (s *Selection) IsNodes(nodes ...*html.Node) bool {
-	return s.FilterNodes(nodes...).Length() > 0
+	for _, n := range s.Nodes {
+		if isInSlice(nodes, n) {
+			return true
+		}
+	}
+	return false
 }
 
 // Contains returns true if the specified Node is within,


### PR DESCRIPTION
These methods were building a full filtered Selection (via FilterFunction/FilterSelection/FilterNodes -> winnow -> grep) only to check Length() > 0. This commit replaces with early-return loops that stop at the first match, significantly speeding them up:

name             old ns/op   new ns/op   delta
IsFunction-8     1530        3.9         -99.7%
IsSelection-8    1890        19.9        -98.9%
IsNodes-8        2016        19.9        -99.0%

name             old B/op    new B/op    delta
IsFunction-8     784         0           -100.0%
IsSelection-8    72          0           -100.0%
IsNodes-8        72          0           -100.0%

name             old allocs  new allocs  delta
IsFunction-8     28          0           -100.0%
IsSelection-8    3           0           -100.0%
IsNodes-8        3           0           -100.0%