### PR TITLE
perf: replace regex+Split with strings.Fields in getClassesSlice

### DIFF
--- a/bench_property_test.go
+++ b/bench_property_test.go
@@ -49,3 +49,22 @@ func BenchmarkHtml(b *testing.B) {
 		_, _ = sel.Html()
 	}
 }
+
+func BenchmarkAddClass(b *testing.B) {
+	b.StopTimer()
+	sel := DocW().Find("li")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.AddClass("foo bar baz")
+	}
+}
+
+func BenchmarkRemoveClass(b *testing.B) {
+	b.StopTimer()
+	sel := DocW().Find("li")
+	sel.AddClass("foo bar baz")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.RemoveClass("foo bar baz")
+	}
+}

--- a/property.go
+++ b/property.go
@@ -253,7 +253,7 @@ func getClassesAndAttr(n *html.Node, create bool) (classes string, attr *html.At
 }
 
 func getClassesSlice(classes string) []string {
-	return strings.Split(rxClassTrim.ReplaceAllString(" "+classes+" ", " "), " ")
+	return strings.Fields(classes)
 }
 
 func removeAttr(n *html.Node, attrName string) {


### PR DESCRIPTION
getClassesSlice used rxClassTrim.ReplaceAllString followed by strings.Split, which allocated twice and produced empty strings from leading/trailing spaces. strings.Fields handles all Unicode whitespace in a single pass with no empty entries.

name             old ns/op   new ns/op   delta
AddClass-8       176700      107500      -39.2%
RemoveClass-8    142900      64600       -54.8%

name             old B/op    new B/op    delta
AddClass-8       12544       7024        -44.0%
RemoveClass-8    6503        1777        -72.7%

name             old allocs  new allocs  delta
AddClass-8       697         374         -46.3%
RemoveClass-8    697         374         -46.3%