### PR TITLE
perf: iterate n.Attr by index in getAttributePtr and removeAttr

### DIFF
--- a/property.go
+++ b/property.go
@@ -210,8 +210,8 @@ func getAttributePtr(attrName string, n *html.Node) *html.Attribute {
 		return nil
 	}
 
-	for i, a := range n.Attr {
-		if a.Key == attrName {
+	for i := range n.Attr {
+		if n.Attr[i].Key == attrName {
 			return &n.Attr[i]
 		}
 	}
@@ -257,8 +257,8 @@ func getClassesSlice(classes string) []string {
 }
 
 func removeAttr(n *html.Node, attrName string) {
-	for i, a := range n.Attr {
-		if a.Key == attrName {
+	for i := range n.Attr {
+		if n.Attr[i].Key == attrName {
 			n.Attr[i], n.Attr[len(n.Attr)-1], n.Attr =
 				n.Attr[len(n.Attr)-1], html.Attribute{}, n.Attr[:len(n.Attr)-1]
 			return


### PR DESCRIPTION
`for i, a := range n.Attr` copies an entire html.Attribute value into `a` on every iteration, only to look at `a.Key`. Switching to `for i := range n.Attr` and indexing into `n.Attr[i].Key` removes the copy.

Both helpers sit on very hot paths:
- getAttributePtr: Attr, AttrOr, SetAttr, getClassesAndAttr (used in AddClass, RemoveClass, ToggleClass and HasClass)
- removeAttr: RemoveAttr, setClasses

While there are no changes in B/op or allocs/op since the copy was stack-only, it speed things up by around 15% on local benchmarks.