### PR TITLE
perf: replace recursive closure in Text() with iterative subtree walk

### DIFF
--- a/property.go
+++ b/property.go
@@ -60,21 +60,33 @@ func (s *Selection) SetAttr(attrName, val string) *Selection {
 func (s *Selection) Text() string {
 	var builder strings.Builder
 
-	// Slightly optimized vs calling Each: no single selection object created
-	var f func(*html.Node)
-	f = func(n *html.Node) {
-		if n.Type == html.TextNode {
+	// Iterative depth-first walk: Walks each root's subtree using FirstChild,
+	// NextSibling and Parent pointers, stopping when it ascends back to the
+	// root so it never escapes the original subtree.
+	for _, root := range s.Nodes {
+		if root.Type == html.TextNode {
 			// Keep newlines and spaces, like jQuery
-			builder.WriteString(n.Data)
+			builder.WriteString(root.Data)
 		}
-		if n.FirstChild != nil {
-			for c := n.FirstChild; c != nil; c = c.NextSibling {
-				f(c)
+		for n := root.FirstChild; n != nil; {
+			if n.Type == html.TextNode {
+				builder.WriteString(n.Data)
 			}
+			// Descend into children first.
+			if n.FirstChild != nil {
+				n = n.FirstChild
+				continue
+			}
+			// Otherwise advance to the next sibling, ascending until we
+			// find one or hit the root.
+			for n != root && n.NextSibling == nil {
+				n = n.Parent
+			}
+			if n == root {
+				break
+			}
+			n = n.NextSibling
 		}
-	}
-	for _, n := range s.Nodes {
-		f(n)
 	}
 
 	return builder.String()


### PR DESCRIPTION
Text() built a self-referencing closure `var f func(*html.Node); f = ...` to recurse into descendants and accumulate text. The closure capture of its own variable forces the compiler to box `f`, and each recursive call pays a Go stack-frame setup.

This commit replaces it with an iterative depth-first walk using FirstChild/NextSibling/Parent pointers, anchored at each root in s.Nodes so the walk never escapes the original subtree.

Allocations are unchanged (the remaining 6/15/19 allocs come from strings.Builder grow-doubling), but ns/op drops by roughly 30-40% across shallow and deep subtrees:

name                old time/op  new time/op  delta
Text-8              1.86µs       1.11µs       -40.4%   (h2, n=14)
TextDeep-8          126µs        86µs         -31.6%   (whole body)
TextManyShallow-8   40.9µs       29.1µs       -28.9%   (all anchors)

All p=0.000 over 10 runs on arm64. B/op and allocs/op are bit-for-bit identical in all three benchmarks.