### PR TITLE
perf: presize set in appendWithoutDuplicates to final expected size

### DIFF
--- a/utilities.go
+++ b/utilities.go
@@ -143,7 +143,7 @@ func appendWithoutDuplicates(target []*html.Node, nodes []*html.Node, targetSet 
 	// if a targetSet is passed, then assume it is reliable, otherwise create one
 	// and initialize it with the current target contents.
 	if targetSet == nil {
-		targetSet = make(map[*html.Node]bool, len(target))
+		targetSet = make(map[*html.Node]bool, len(target)+len(nodes))
 		for _, n := range target {
 			targetSet[n] = true
 		}


### PR DESCRIPTION
BenchmarkAddNodesBig (DocW().Find("li") duplicated to ~1500 nodes, then AddNodes onto an empty selection), -count=20:

                 sec/op             B/op           allocs/op
    before    214.3µs ±12%     27.58Ki ±0%       24
    after     104.8µs ±24%     45.24Ki ±0%       16
                  -51%             +64%          -33%

The B/op increase is the cost of presizing the map to its final capacity in one shot rather than letting the runtime grow it through smaller bucket arrays (which are freed but counted in total bytes allocated). Peak resident memory is comparable.