### PR TITLE
perf: collapse per-child loop in findWithMatcher

### DIFF
--- a/traversal.go
+++ b/traversal.go
@@ -546,14 +546,15 @@ func filterAndPush(srcSel *Selection, nodes []*html.Node, m Matcher) *Selection 
 // Internal implementation of Find that return raw nodes.
 func findWithMatcher(nodes []*html.Node, m Matcher) []*html.Node {
 	// Map nodes to find the matches within the children of each node
-	return mapNodes(nodes, func(i int, n *html.Node) (result []*html.Node) {
-		// Go down one level, becausejQuery's Find selects only within descendants
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			if c.Type == html.ElementNode {
-				result = append(result, m.MatchAll(c)...)
-			}
+	return mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
+		// jQuery's Find selects only descendants, not n itself. cascadia's
+		// MatchAll walks n + all descendants in document order, so if n
+		// matches it's always the first element and we can drop it.
+		all := m.MatchAll(n)
+		if len(all) > 0 && all[0] == n {
+			return all[1:]
 		}
-		return
+		return all
 	})
 }
 


### PR DESCRIPTION
findWithMatcher iterated over each element child of every input node and called m.MatchAll(c) on each, then append-spread-merged the returned slices into one result. For a node with K element children this was K independent cascadia tree walks, each starting with a fresh nil result slice.

This commit calls m.MatchAll(n) once on the input node itself. cascadia walks n plus all descendants in document order, so if n matches it is always the first element of the returned slice, strip it to preserve jQuery Find's "descendants only" semantics.

Benchmarks (-count=20, benchtime=500ms, linux/arm64):

                          sec/op           B/op             allocs/op
    Find                  ~ (-10%)         -23.53%          -7.69%
    FindWithinSelection   ~                -11.06%          -43.53%
    FindNodes             -12.36%          ~                ~
    Has                   ~                -17.20%          -7.14%
    Add                   ~                 -5.13%          -9.09%
    Closest               -37.34%          ~                ~
    ClosestSelection      -43.77%          ~                ~
    ClosestNodes          -36.56%          ~                ~
    MetalReviewExample    ~                 -5.42%         -11.19%