### PR TITLE
perf: collect parent nodes inline in getParentNodes

### DIFF
--- a/traversal.go
+++ b/traversal.go
@@ -676,12 +676,21 @@ func getChildrenWithSiblingType(parent *html.Node, st siblingType, skipNode *htm
 
 // Internal implementation of parent nodes that return a raw slice of Nodes.
 func getParentNodes(nodes []*html.Node) []*html.Node {
-	return mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
-		if n.Parent != nil && n.Parent.Type == html.ElementNode {
-			return []*html.Node{n.Parent}
+	// Collect parents inline rather than going through mapNodes, which would
+	// allocate a throwaway one-element slice per source node. Many source
+	// nodes (e.g. siblings) share the same parent, so deduplicate as we go.
+	var result []*html.Node
+	set := make(map[*html.Node]bool, len(nodes))
+
+	for _, n := range nodes {
+		p := n.Parent
+		if p == nil || p.Type != html.ElementNode || set[p] {
+			continue
 		}
-		return nil
-	})
+		set[p] = true
+		result = append(result, p)
+	}
+	return result
 }
 
 // Internal map function used by many traversing methods. Takes the source nodes


### PR DESCRIPTION
getParentNodes ran through mapNodes with a callback that allocated a throwaway one-element []*html.Node{n.Parent} for every source node. Since sibling nodes share the same parent, almost all of those slices were immediately discarded as duplicates.

This commit collects the parents directly in a single loop, deduplicating via a set as we go, so no per-node slice is allocated.

```
benchstat (count=10, all p=0.000):

                 |   before    |             after            |
                 |   sec/op    |    sec/op     vs base        |
Parent-8         | 38.54µ ± 21%|  17.49µ ± 14%  -54.63%       |
ParentFiltered-8 | 46.57µ ± 13%|  20.91µ ± 24%  -55.09%       |

                 |   before    |             after            |
                 |    B/op     |     B/op      vs base        |
Parent-8         | 13.24Ki ± 0%|  10.28Ki ± 0%  -22.36%       |
ParentFiltered-8 | 13.49Ki ± 0%|  10.58Ki ± 0%  -21.60%       |

                 |   before    |            after             |
                 |  allocs/op  | allocs/op   vs base          |
Parent-8         |  384.0 ± 0% | 10.00 ± 0%  -97.40%          |
ParentFiltered-8 |  392.0 ± 0% | 19.00 ± 0%  -95.15%          |
```