### PR TITLE
perf: probe with MatchFirst in HasMatcher to avoid slice allocation

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -88,27 +88,15 @@ func (s *Selection) Has(selector string) *Selection {
 func (s *Selection) HasMatcher(m Matcher) *Selection {
 	result := make([]*html.Node, 0, len(s.Nodes))
 
-	// If the matcher can probe for the first match in a subtree without
-	// building a result slice, use that: it avoids a throwaway one-element
-	// slice allocation for every matching child subtree.
-	if mf, ok := m.(interface {
-		MatchFirst(*html.Node) *html.Node
-	}); ok {
-		for _, n := range s.Nodes {
-			for c := n.FirstChild; c != nil; c = c.NextSibling {
-				if c.Type == html.ElementNode && mf.MatchFirst(c) != nil {
-					result = append(result, n)
-					break
-				}
-			}
-		}
-		return pushStack(s, result)
-	}
-
-	m = SingleMatcher(m)
+	// Manually create a singleMatcher (rather than using SingleMatcher, which
+	// returns a Matcher interface) so we can call its MatchFirst method
+	// directly. MatchFirst probes for the first match in a subtree without
+	// building a result slice, avoiding a throwaway one-element slice
+	// allocation for every matching child subtree.
+	sm := singleMatcher{m}
 	for _, n := range s.Nodes {
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			if c.Type == html.ElementNode && len(m.MatchAll(c)) > 0 {
+			if c.Type == html.ElementNode && sm.MatchFirst(c) != nil {
 				result = append(result, n)
 				break
 			}

--- a/filter.go
+++ b/filter.go
@@ -87,6 +87,24 @@ func (s *Selection) Has(selector string) *Selection {
 // It returns a new Selection object with the matching elements.
 func (s *Selection) HasMatcher(m Matcher) *Selection {
 	result := make([]*html.Node, 0, len(s.Nodes))
+
+	// If the matcher can probe for the first match in a subtree without
+	// building a result slice, use that: it avoids a throwaway one-element
+	// slice allocation for every matching child subtree.
+	if mf, ok := m.(interface {
+		MatchFirst(*html.Node) *html.Node
+	}); ok {
+		for _, n := range s.Nodes {
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				if c.Type == html.ElementNode && mf.MatchFirst(c) != nil {
+					result = append(result, n)
+					break
+				}
+			}
+		}
+		return pushStack(s, result)
+	}
+
 	m = SingleMatcher(m)
 	for _, n := range s.Nodes {
 		for c := n.FirstChild; c != nil; c = c.NextSibling {

--- a/type.go
+++ b/type.go
@@ -175,22 +175,31 @@ type singleMatcher struct {
 	Matcher
 }
 
-func (m singleMatcher) MatchAll(n *html.Node) []*html.Node {
+// MatchFirst returns the first node that matches, or nil if none does. It uses
+// the underlying Matcher's MatchFirst method if it provides one (cascadia-
+// compiled matchers all do), avoiding building a result slice. Otherwise it
+// falls back to MatchAll and returns its first element.
+func (m singleMatcher) MatchFirst(n *html.Node) *html.Node {
 	// Optimized version - stops finding at the first match (cascadia-compiled
 	// matchers all use this code path).
 	if mm, ok := m.Matcher.(interface{ MatchFirst(*html.Node) *html.Node }); ok {
-		node := mm.MatchFirst(n)
-		if node == nil {
-			return nil
-		}
-		return []*html.Node{node}
+		return mm.MatchFirst(n)
 	}
 
 	// Fallback version, for e.g. test mocks that don't provide the MatchFirst
 	// method.
 	nodes := m.Matcher.MatchAll(n)
 	if len(nodes) > 0 {
-		return nodes[:1:1]
+		return nodes[0]
+	}
+	return nil
+}
+
+func (m singleMatcher) MatchAll(n *html.Node) []*html.Node {
+	// Wrap MatchFirst's single result in a slice to respect the Matcher
+	// interface's MatchAll signature.
+	if node := m.MatchFirst(n); node != nil {
+		return []*html.Node{node}
 	}
 	return nil
 }


### PR DESCRIPTION
HasMatcher only needs to know whether a child subtree contains a match, but it tested len(m.MatchAll(c)) > 0 after wrapping the matcher with SingleMatcher. SingleMatcher.MatchAll computes MatchFirst internally and then wraps the result in a throwaway []*html.Node{node}, allocating a one-element slice per matching child subtree just to check a boolean.

When the matcher exposes MatchFirst, probe it directly and test the returned node against nil, avoiding the allocation entirely. This is the same trick already used in SingleMatcher.MatchAll, just applied at the HasMatcher call site so the intermediate slice is never built in the first place. The SingleMatcher path is kept as a fallback for matchers that don't implement MatchFirst.

```
benchstat (count=10):

      | before       |              after   |
      | sec/op       |    sec/op     vs base|
Has-8 | 2.675µ ± 17% | 2.208µ ± 17%  -17.47%|

      | before       |             after    |
      |  B/op        |    B/op     vs base  |
Has-8 | 360.0 ± 0%   | 240.0 ± 0%  -33.33%  |

      | before       |             after    |
      |allocs/op     | allocs/op   vs base  |
Has-8 | 20.00 ± 0%   |  6.000 ± 0%  -70.00% |
```