### PR TITLE
perf: skip dedup map in getChildrenNodes

### DIFF
--- a/traversal.go
+++ b/traversal.go
@@ -604,9 +604,22 @@ func getSiblingNodes(nodes []*html.Node, st siblingType, untilm Matcher, untilNo
 // Gets the children nodes of each node in the specified slice of nodes,
 // based on the sibling type request.
 func getChildrenNodes(nodes []*html.Node, st siblingType) []*html.Node {
-	return mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
-		return getChildrenWithSiblingType(n, st, nil, nil)
-	})
+	// Each child has exactly one parent, so the children of distinct source
+	// nodes form disjoint sets: there is nothing to deduplicate across them.
+	// Skip mapNodes' per-call dedup map and append directly, while keeping the
+	// single-node fast path that returns the slice without an extra copy.
+	switch len(nodes) {
+	case 0:
+		return nil
+	case 1:
+		return getChildrenWithSiblingType(nodes[0], st, nil, nil)
+	}
+
+	var result []*html.Node
+	for _, n := range nodes {
+		result = append(result, getChildrenWithSiblingType(n, st, nil, nil)...)
+	}
+	return result
 }
 
 // Gets the children of the specified parent, based on the requested sibling


### PR DESCRIPTION
getChildrenNodes went through mapNodes, which builds a map[*html.Node]bool to deduplicate results merged across source nodes. That dedup is pointless in this case: every child has exactly one parent, so the children of distinct (already-unique) source nodes form disjoint sets and can never collide. Walk the sources directly into the result instead, keeping a single-node fast path that returns the child slice without an extra copy.

This mirrors the disjoint-set reasoning already applied to the parent traversal helpers.

benchstat -count=10:

                    sec/op       B/op           allocs/op
Contents-8          -55.52%      -67.63%        -19.23%
ContentsFiltered-8  -15.25%      -33.61%        -9.68%
ChildrenFiltered-8  -32.84%      -3.23%         -7.69%
Children-8          ~ (single-node fast path unchanged)