### PR TITLE
perf: inline dedup loop in getParentNodes

### DIFF
--- a/traversal.go
+++ b/traversal.go
@@ -676,12 +676,27 @@ func getChildrenWithSiblingType(parent *html.Node, st siblingType, skipNode *htm
 
 // Internal implementation of parent nodes that return a raw slice of Nodes.
 func getParentNodes(nodes []*html.Node) []*html.Node {
-	return mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
-		if n.Parent != nil && n.Parent.Type == html.ElementNode {
-			return []*html.Node{n.Parent}
+	switch len(nodes) {
+	case 0:
+		return nil
+	case 1:
+		if p := nodes[0].Parent; p != nil && p.Type == html.ElementNode {
+			return []*html.Node{p}
 		}
 		return nil
-	})
+	}
+
+	// Sibling nodes share a parent, so dedup directly into a set instead of
+	// allocating a throwaway one-element slice per node through mapNodes.
+	var result []*html.Node
+	set := make(map[*html.Node]bool, len(nodes))
+	for _, n := range nodes {
+		if p := n.Parent; p != nil && p.Type == html.ElementNode && !set[p] {
+			set[p] = true
+			result = append(result, p)
+		}
+	}
+	return result
 }
 
 // Internal map function used by many traversing methods. Takes the source nodes


### PR DESCRIPTION
getParentNodes routed Parent/ParentFiltered through mapNodes with a closure returning a one-element []*html.Node{n.Parent} per source node. On a sibling selection nearly all of those slices point at the same parent and are immediately deduped away.

This commit walks s.Nodes directly instead: for a single node, return its parent with no map; for many, dedup parents into a shared set while appending. This removes the per-node slice allocation at the source rather than cleaning it up downstream.

benchstat (count=10, all p=0.000):

  allocs/op    Parent 384->7 (-98%), ParentFiltered 392->16 (-96%)
  sec/op       Parent -78%, ParentFiltered -59%
  B/op         both -22%