### PR TITLE
perf: skip dedup map in FindNodes

### DIFF
--- a/traversal.go
+++ b/traversal.go
@@ -51,12 +51,19 @@ func (s *Selection) FindSelection(sel *Selection) *Selection {
 // Selection, filtered by some nodes. It returns a new Selection object
 // containing these matched elements.
 func (s *Selection) FindNodes(nodes ...*html.Node) *Selection {
-	return pushStack(s, mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
-		if sliceContains(s.Nodes, n) {
-			return []*html.Node{n}
+	// Each source node maps to at most itself (when it is a descendant of the
+	// current selection), so there is nothing to deduplicate across distinct
+	// sources. Skip mapNodes' callback indirection and append matches directly,
+	// while still discarding duplicate input nodes so the resulting Selection
+	// stays a proper set. The cheap isInSlice check runs first so duplicate
+	// inputs short-circuit before the more expensive sliceContains tree walk.
+	var result []*html.Node
+	for _, n := range nodes {
+		if !isInSlice(result, n) && sliceContains(s.Nodes, n) {
+			result = append(result, n)
 		}
-		return nil
-	}))
+	}
+	return pushStack(s, result)
 }
 
 // Contents gets the children of each element in the Selection,

--- a/traversal_test.go
+++ b/traversal_test.go
@@ -36,6 +36,16 @@ func TestFindBig(t *testing.T) {
 	assertLength(t, sel3.Nodes, 248)
 }
 
+func TestFindNodesDuplicateInput(t *testing.T) {
+	doc := DocW()
+	sel := doc.Find("body")
+	span := doc.Find("span").Nodes[0]
+	// Duplicate input nodes must be discarded so the resulting Selection
+	// stays a proper set.
+	sel2 := sel.FindNodes(span, span)
+	assertLength(t, sel2.Nodes, 1)
+}
+
 func TestChainedFind(t *testing.T) {
 	sel := Doc().Find("div.hero-unit").Find(".row-fluid")
 	assertLength(t, sel.Nodes, 4)


### PR DESCRIPTION
FindNodes went through mapNodes, which builds a map[*html.Node]bool to deduplicate results merged across source nodes, and wrapped every match in a one-element []*html.Node slice. Both are wasteful here: each source node maps to at most itself (when it is a descendant of the current selection), so distinct source nodes can never collide. Append the matching nodes directly into the result instead.

Duplicate *input* nodes still have to be discarded so the resulting Selection stays a proper set, which mapNodes previously handled via appendWithoutDuplicates. A cheap isInSlice check against the (small) result slice preserves that, and is placed before the more expensive sliceContains tree walk so duplicate inputs short-circuit early.

benchstat -count=12:

               |   old    |             new
               |  sec/op  |   sec/op     vs base
FindNodes-8    | 232.6µ   | 131.0µ       -43.68% (p=0.000 n=12)

               |   old    |             new
               |   B/op   |      B/op      vs base
FindNodes-8    | 12.023Ki |  2.164Ki      -82.00% (p=0.000 n=12)

               |   old    |            new
               | allocs/op| allocs/op   vs base
FindNodes-8    | 85.000   |  9.000       -89.41% (p=0.000 n=12)