### PR TITLE
perf: skip make+copy in cloneNode for attribute-less nodes

### DIFF
--- a/manipulation.go
+++ b/manipulation.go
@@ -608,10 +608,14 @@ func cloneNode(n *html.Node) *html.Node {
 		Type:     n.Type,
 		DataAtom: n.DataAtom,
 		Data:     n.Data,
-		Attr:     make([]html.Attribute, len(n.Attr)),
 	}
 
-	copy(nn.Attr, n.Attr)
+	// Skip the make+copy call pair when the source has no attributes.
+	if len(n.Attr) > 0 {
+		nn.Attr = make([]html.Attribute, len(n.Attr))
+		copy(nn.Attr, n.Attr)
+	}
+
 	for c := n.FirstChild; c != nil; c = c.NextSibling {
 		nn.AppendChild(cloneNode(c))
 	}


### PR DESCRIPTION
Guard the Attr slice initialization with len(n.Attr) > 0. make([]T, 0) is zero-alloc in Go (returns a header into runtime.zerobase), so this does not change B/op or allocs/op, but it removes a runtime.makeslice call and a copy() call per attribute-less node. Text nodes (the majority of nodes in real HTML) and many element nodes have no attributes, so the saving applies to most of the recursion.

  BenchmarkCloneDocument       -5.7%  (844463 -> 796520 ns/op)
  BenchmarkSelectionClone      -7.2%  ( 68557 ->  63654 ns/op)
  BenchmarkSelectionCloneAll   -6.8%  (9459930 -> 8813318 ns/op)
  B/op, allocs/op:             unchanged

So nothing ground-breaking, but the change is minimal, so worth it.