### PR TITLE
perf: detach children inline in Empty()

### DIFF
--- a/manipulation.go
+++ b/manipulation.go
@@ -169,10 +169,20 @@ func (s *Selection) Empty() *Selection {
 	var nodes []*html.Node
 
 	for _, n := range s.Nodes {
-		for c := n.FirstChild; c != nil; c = n.FirstChild {
-			n.RemoveChild(c)
+		// Detach all children in one pass. Since each child is being
+		// removed from its only parent and ends up with no siblings,
+		// we can inline what RemoveChild does for the FirstChild case
+		// and skip the per-iter FirstChild/LastChild bookkeeping.
+		for c := n.FirstChild; c != nil; {
+			next := c.NextSibling
+			c.Parent = nil
+			c.PrevSibling = nil
+			c.NextSibling = nil
 			nodes = append(nodes, c)
+			c = next
 		}
+		n.FirstChild = nil
+		n.LastChild = nil
 	}
 
 	return pushStack(s, nodes)


### PR DESCRIPTION
Empty() called n.RemoveChild(c) in a loop where c was always the FirstChild. RemoveChild's general logic is overkill for that case: the panic-check on c.Parent is always true, the PrevSibling branch is always nil, the FirstChild reassignment is overwritten on every iteration, and the LastChild check only ever matches on the final child.

Walk the sibling chain once via NextSibling, nil out each detached child's parent/sibling pointers, and clear n.FirstChild / n.LastChild exactly once at the end.