### PR TITLE
perf: avoid temp html.Attribute in removeAttr's swap-and-shrink

### DIFF
--- a/property.go
+++ b/property.go
@@ -263,8 +263,10 @@ func getClassesSlice(classes string) []string {
 func removeAttr(n *html.Node, attrName string) {
 	for i, a := range n.Attr {
 		if a.Key == attrName {
-			n.Attr[i], n.Attr[len(n.Attr)-1], n.Attr =
-				n.Attr[len(n.Attr)-1], html.Attribute{}, n.Attr[:len(n.Attr)-1]
+			last := len(n.Attr) - 1
+			n.Attr[i] = n.Attr[last]
+			n.Attr[last] = html.Attribute{}
+			n.Attr = n.Attr[:last]
 			return
 		}
 	}


### PR DESCRIPTION
The tuple-form

    n.Attr[i], n.Attr[len-1], n.Attr =
        n.Attr[len-1], html.Attribute{}, n.Attr[:len-1]

forces the compiler to evaluate all three RHS expressions into temporaries before writing any LHS, materialising a full html.Attribute (three string headers, 6 words) on the stack on every call.

This commit splits it into sequential statements lets the compiler store n.Attr[last] directly into n.Attr[i], memclr the trailing slot in place, and reslice. While the performance gains are negligible (~3%), the main gain here is readability, as it's not super-duper-obvious what was going on here.