### PR TITLE
cleanup: drop redundant FirstChild nil-check in textHelper

### DIFF
--- a/property.go
+++ b/property.go
@@ -71,10 +71,8 @@ func (s *Selection) textHelper(n *html.Node, builder *strings.Builder) {
 		// Keep newlines and spaces, like jQuery
 		builder.WriteString(n.Data)
 	}
-	if n.FirstChild != nil {
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			s.textHelper(c, builder)
-		}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		s.textHelper(c, builder)
 	}
 }
 


### PR DESCRIPTION
The `for c := n.FirstChild; c != nil; c = c.NextSibling` loop already handles the nil-FirstChild case.