### PR TITLE
Add top-level Text function for BeautifulSoup-style text extraction

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
 )
 
 // This example scrapes the reviews shown on the home page of metalsucks.net.
@@ -107,4 +108,41 @@ func ExampleSingle() {
 	// Output:
 	// 123
 	// 1
+}
+
+// This example shows how to use the goquery.Text function to extract clean,
+// human-readable text from a selection, similar to BeautifulSoup's get_text.
+func ExampleText() {
+	page := `
+<html>
+  <body>
+    <div id="content">
+      <h1>  Hello  </h1>
+      <p>world</p>
+      <script>var ignored = 1;</script>
+    </div>
+  </body>
+</html>
+`
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(page))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Trim each text node, join the remaining ones with a space, and skip the
+	// text of <script> and <style> elements.
+	text := goquery.Text(doc.Find("#content"), &goquery.TextOptions{
+		Separator: " ",
+		Trim:      true,
+		Keep: func(n *html.Node) bool {
+			if p := n.Parent; p != nil && p.Type == html.ElementNode {
+				return p.Data != "script" && p.Data != "style"
+			}
+			return true
+		},
+	})
+	fmt.Println(text)
+
+	// Output:
+	// Hello world
 }

--- a/utilities.go
+++ b/utilities.go
@@ -57,6 +57,72 @@ func nodeName(node *html.Node) string {
 	}
 }
 
+// TextOptions controls the behaviour of the Text function.
+type TextOptions struct {
+	// Separator is inserted between the contents of the text nodes that are
+	// included in the result. It defaults to the empty string, which
+	// concatenates the text nodes without any separator.
+	Separator string
+
+	// Trim, when true, removes leading and trailing whitespace from the
+	// content of each text node and omits text nodes that are empty once
+	// trimmed. This is useful to discard the insignificant whitespace that
+	// comes from the indentation of the source HTML.
+	Trim bool
+
+	// Keep, when non-nil, is called for each text node encountered while
+	// traversing the selection. The content of the text node is included in
+	// the result only if Keep returns true. It can be used, for example, to
+	// drop the text of <script> and <style> elements by inspecting the node's
+	// parent. When Keep is nil, every text node is included (subject to Trim).
+	Keep func(node *html.Node) bool
+}
+
+// Text returns the combined text contents of the nodes in the selection,
+// including their descendants, in document order. It is a package-level
+// function - and not a method on the Selection, because it is not part of the
+// jQuery API - that offers control over how the text of distinct text nodes is
+// joined and which text nodes are included, in the same spirit as Python's
+// BeautifulSoup get_text.
+//
+// With a nil opts (or a zero-value TextOptions), Text behaves like calling the
+// Selection.Text method on the selection. Setting TextOptions.Separator inserts
+// a separator between the text nodes, Trim strips the surrounding whitespace of
+// each text node (dropping the ones that become empty), and Keep filters which
+// text nodes contribute to the result.
+func Text(s *Selection, opts *TextOptions) string {
+	if opts == nil {
+		opts = &TextOptions{}
+	}
+
+	var parts []string
+	var collect func(*html.Node)
+	collect = func(n *html.Node) {
+		if n.Type == html.TextNode {
+			if opts.Keep != nil && !opts.Keep(n) {
+				return
+			}
+			text := n.Data
+			if opts.Trim {
+				text = strings.TrimSpace(text)
+				if text == "" {
+					return
+				}
+			}
+			parts = append(parts, text)
+			return
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			collect(c)
+		}
+	}
+	for _, n := range s.Nodes {
+		collect(n)
+	}
+
+	return strings.Join(parts, opts.Separator)
+}
+
 // Render renders the HTML of the first item in the selection and writes it to
 // the writer. It behaves the same as OuterHtml but writes to w instead of
 // returning the string.

--- a/utilities_test.go
+++ b/utilities_test.go
@@ -158,6 +158,35 @@ func TestText_MultiSelection(t *testing.T) {
 	}
 }
 
+func TestText_EmptySelection(t *testing.T) {
+	doc, err := NewDocumentFromReader(strings.NewReader(textNodes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// An empty selection has no text nodes to walk, so the result is empty
+	// and the call must not panic.
+	got := Text(doc.Find(".no-such-thing"), &TextOptions{Separator: " ", Trim: true})
+	if got != "" {
+		t.Errorf("want empty string, got %q", got)
+	}
+}
+
+func TestText_KeepFiltersAll(t *testing.T) {
+	doc, err := NewDocumentFromReader(strings.NewReader(textNodes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// When Keep rejects every text node, nothing is joined and the result is
+	// empty rather than a string of separators.
+	keep := func(n *html.Node) bool { return false }
+	got := Text(doc.Find("#content"), &TextOptions{Separator: " ", Trim: true, Keep: keep})
+	if got != "" {
+		t.Errorf("want empty string, got %q", got)
+	}
+}
+
 func TestOuterHtml(t *testing.T) {
 	doc, err := NewDocumentFromReader(strings.NewReader(allNodes))
 	if err != nil {

--- a/utilities_test.go
+++ b/utilities_test.go
@@ -81,6 +81,83 @@ func TestNodeNameMultiSel(t *testing.T) {
 	}
 }
 
+var textNodes = `<!doctype html>
+<html>
+	<body>
+		<div id="content">
+			<h1>  Hello  </h1>
+			<p>world</p>
+			<!-- a comment -->
+			<script>var ignored = 1;</script>
+		</div>
+	</body>
+</html>`
+
+func TestText_NilOptions(t *testing.T) {
+	doc, err := NewDocumentFromReader(strings.NewReader(textNodes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sel := doc.Find("#content")
+	// A nil options value must behave exactly like the Text method.
+	if got, want := Text(sel, nil), sel.Text(); got != want {
+		t.Errorf("nil options: want %q, got %q", want, got)
+	}
+}
+
+func TestText_SeparatorAndTrim(t *testing.T) {
+	doc, err := NewDocumentFromReader(strings.NewReader(textNodes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Trim drops the whitespace-only text nodes coming from indentation, and
+	// Separator joins the remaining fragments. The <script> text is included
+	// because no Keep filter is provided.
+	got := Text(doc.Find("#content"), &TextOptions{Separator: "|", Trim: true})
+	want := "Hello|world|var ignored = 1;"
+	if got != want {
+		t.Errorf("want %q, got %q", want, got)
+	}
+}
+
+func TestText_Keep(t *testing.T) {
+	doc, err := NewDocumentFromReader(strings.NewReader(textNodes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Keep skips the text of <script> (and <style>) elements.
+	keep := func(n *html.Node) bool {
+		if n.Parent != nil && n.Parent.Type == html.ElementNode {
+			switch n.Parent.Data {
+			case "script", "style":
+				return false
+			}
+		}
+		return true
+	}
+	got := Text(doc.Find("#content"), &TextOptions{Separator: " ", Trim: true, Keep: keep})
+	want := "Hello world"
+	if got != want {
+		t.Errorf("want %q, got %q", want, got)
+	}
+}
+
+func TestText_MultiSelection(t *testing.T) {
+	doc, err := NewDocumentFromReader(strings.NewReader(textNodes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := Text(doc.Find("h1, p"), &TextOptions{Separator: ",", Trim: true})
+	want := "Hello,world"
+	if got != want {
+		t.Errorf("want %q, got %q", want, got)
+	}
+}
+
 func TestOuterHtml(t *testing.T) {
 	doc, err := NewDocumentFromReader(strings.NewReader(allNodes))
 	if err != nil {


### PR DESCRIPTION
This adds `goquery.Text(s *Selection, opts *TextOptions)`, a top-level counterpart to the `Selection.Text` method that gives control over how text is extracted, so callers can get clean, readable text out of a document without hand-rolling a node walk.

This is the feature discussed in #443, where the request was to offer something similar to Python BeautifulSoup's `get_text`. As suggested there, it is a package-level function rather than a `Selection` method (to keep the method set aligned with the jQuery API, like `NodeName` and `OuterHtml`), and it is "general enough" via a small options struct:

- `Separator` is inserted between the contents of consecutive text nodes.
- `Trim` strips leading/trailing whitespace from each text node and drops the ones that become empty (the insignificant whitespace from source indentation).
- `Keep` is an optional predicate called per text node; returning false excludes it, which is how a caller drops the text of `<script>`/`<style>` elements by inspecting the node's parent.

A `nil` (or zero-value) `TextOptions` makes `Text` behave exactly like `Selection.Text`, so the default is unsurprising and the traversal semantics match the existing method.

Example:

```go
text := goquery.Text(doc.Find("#content"), &goquery.TextOptions{
    Separator: " ",
    Trim:      true,
    Keep: func(n *html.Node) bool {
        if p := n.Parent; p != nil && p.Type == html.ElementNode {
            return p.Data != "script" && p.Data != "style"
        }
        return true
    },
})
```

Tests cover the nil-options equivalence to `Selection.Text`, the separator/trim behaviour, the `Keep` filter, and a multi-node selection; a runnable `ExampleText` is included as documentation. `go test ./...`, `go vet ./...`, and `gofmt` are all clean.

Closes #443.
