### PR TITLE
HasClass false negative with non-space whitespace

### DIFF
--- a/property.go
+++ b/property.go
@@ -129,18 +129,14 @@ func (s *Selection) AddClass(class ...string) *Selection {
 // HasClass determines whether any of the matched elements are assigned the
 // given class.
 func (s *Selection) HasClass(class string) bool {
-	rawClass := class
-	class = " " + class + " "
+	rawClass := " " + class + " "
 	for _, n := range s.Nodes {
 		if n.Type != html.ElementNode {
 			continue
 		}
 		if attr := getAttributePtr("class", n); attr != nil {
-			if !strings.Contains(attr.Val, rawClass) {
-				continue
-			}
-			val := classTrimReplacer.Replace(attr.Val)
-			if strings.Contains(" "+val+" ", class) {
+			val := classTrimReplacer.Replace(" " + attr.Val + " ")
+			if strings.Contains(val, rawClass) {
 				return true
 			}
 		}


### PR DESCRIPTION
```
if !strings.Contains(attr.Val, rawClass) {   // fast path: checks RAW value
	continue
}
val := classTrimReplacer.Replace(attr.Val)  // normalized value never reached
```

1. The early exit used the raw value. For class="a\tb" and HasClass("b"), the raw value contains no " b " substring, so the function continued before the normalized check ever ran. The normalization was dead code for exactly the inputs it was written for.
2. Even on the surviving path, the bounds weren't padded. class="a b" with a single space does contain " b ", but a value where the target class is the only class, like class="b", would fail both checks since there's no trailing space.