### PR TITLE
HasMatcher misses direct children that match the selector

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -88,15 +88,15 @@ func (s *Selection) Has(selector string) *Selection {
 func (s *Selection) HasMatcher(m Matcher) *Selection {
 	result := make([]*html.Node, 0, len(s.Nodes))
 
-	// Manually create a singleMatcher (rather than using SingleMatcher, which
-	// returns a Matcher interface) so we can call its MatchFirst method
-	// directly. MatchFirst probes for the first match in a subtree without
+	// A direct child can itself satisfy the matcher, so the child must be
+	// tested with Match in addition to its subtree being probed with
+	// MatchFirst. MatchFirst probes a subtree for the first match without
 	// building a result slice, avoiding a throwaway one-element slice
 	// allocation for every matching child subtree.
 	sm := singleMatcher{m}
 	for _, n := range s.Nodes {
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			if c.Type == html.ElementNode && sm.MatchFirst(c) != nil {
+			if c.Type == html.ElementNode && (m.Match(c) || sm.MatchFirst(c) != nil) {
 				result = append(result, n)
 				break
 			}


### PR DESCRIPTION
Cascadia's MatchFirst(c) searches c's descendants, not c itself. So an element whose direct child matches the selector is never selected: doc.Find("div").Has("span") on <div><span>x</span></div> returns an empty selection. The MatchFirst "optimization" changed the semantics from "any descendant matches" to "any grandchild-or-deeper matches". Fix: also test the child directly — if m.Match(c) || sm.MatchFirst(c) != nil — or revert to the containment-based implementation (s.HasNodes(m.MatchAll(s.document.rootNode)...)).