### PR TITLE
RemoveClass leaves a class behind when the source repeats it

### DIFF
--- a/property.go
+++ b/property.go
@@ -167,7 +167,7 @@ func (s *Selection) RemoveClass(class ...string) *Selection {
 		} else {
 			classes, attr := getClassesAndAttr(n)
 			for _, rcl := range rclasses {
-				classes = strings.ReplaceAll(classes, " "+rcl+" ", " ")
+				classes = removeClassFromClasses(classes, rcl)
 			}
 
 			setClasses(n, attr, classes)
@@ -191,9 +191,8 @@ func (s *Selection) ToggleClass(class ...string) *Selection {
 	for _, n := range s.Nodes {
 		classes, attr := getClassesAndAttr(n)
 		for _, tcl := range tcls {
-			spaceAroundTcl := " " + tcl + " "
-			if strings.Contains(classes, spaceAroundTcl) {
-				classes = strings.ReplaceAll(classes, spaceAroundTcl, " ")
+			if strings.Contains(classes, " "+tcl+" ") {
+				classes = removeClassFromClasses(classes, tcl)
 			} else {
 				classes += tcl + " "
 			}
@@ -203,6 +202,20 @@ func (s *Selection) ToggleClass(class ...string) *Selection {
 	}
 
 	return s
+}
+
+// removeClassFromClasses removes every occurrence of cl from the normalized
+// class string. One ReplaceAll pass is not enough: adjacent occurrences
+// share the space between them, so " a a " holds only one " a ".
+func removeClassFromClasses(classes, cl string) string {
+	target := " " + cl + " "
+	for {
+		replaced := strings.Replace(classes, target, " ", 1)
+		if replaced == classes {
+			return classes
+		}
+		classes = replaced
+	}
 }
 
 func getAttributePtr(attrName string, n *html.Node) *html.Attribute {

--- a/property_test.go
+++ b/property_test.go
@@ -250,3 +250,62 @@ func TestToggleClass(t *testing.T) {
 		t.Errorf("Expected #nf1 to have no classes, have %q", a)
 	}
 }
+
+func TestRemoveClassRepeatedInSource(t *testing.T) {
+	cases := []struct {
+		class    string
+		remove   string
+		expected string
+	}{
+		{"a a", "a", ""},
+		{"a a a", "a", ""},
+		{"a b a", "a", "b"},
+		{"a b a b", "a", "b b"},
+		{"a b a b", "a b", ""},
+		{"a a b", "a", "b"},
+		{"b a a", "a", "b"},
+	}
+
+	for _, c := range cases {
+		doc, err := NewDocumentFromReader(strings.NewReader(`<div id="t" class="` + c.class + `"></div>`))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sel := doc.Find("#t")
+		sel.RemoveClass(c.remove)
+
+		got, _ := sel.Attr("class")
+		if got != c.expected {
+			t.Errorf("class=%q RemoveClass(%q): got class %q, want %q", c.class, c.remove, got, c.expected)
+		}
+
+		for _, removed := range strings.Fields(c.remove) {
+			if sel.HasClass(removed) {
+				t.Errorf("class=%q RemoveClass(%q): still has class %q", c.class, c.remove, removed)
+			}
+		}
+	}
+}
+
+func TestToggleClassRepeatedInSource(t *testing.T) {
+	doc, err := NewDocumentFromReader(strings.NewReader(`<div id="t" class="a a b"></div>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sel := doc.Find("#t")
+
+	sel.ToggleClass("a")
+	if sel.HasClass("a") {
+		t.Error("expected #t to not have class a after toggling it off")
+	}
+	if !sel.HasClass("b") {
+		t.Error("expected #t to keep class b")
+	}
+
+	sel.ToggleClass("a")
+	if !sel.HasClass("a") {
+		t.Error("expected #t to have class a after toggling it back on")
+	}
+}


### PR DESCRIPTION

## Problem

`RemoveClass` deletes each class with one non-overlapping pass:

```go
classes = strings.ReplaceAll(classes, " "+rcl+" ", " ")   // property.go:170
```

`getClassesAndAttr` returns the list wrapped in spaces, so `class="a a"` becomes
`" a a "`. Two adjacent occurrences share the space between them, and that
string contains only **one** non-overlapping `" a "`. `ReplaceAll` consumes it,
resumes past the replacement, and never sees the second one.

The result is that `RemoveClass` returns with the class still on the element:

```go
doc, _ := goquery.NewDocumentFromReader(strings.NewReader(`<div id="t" class="a a"></div>`))
sel := doc.Find("#t")

sel.RemoveClass("a")

sel.HasClass("a")      // true
sel.Attr("class")      // "a", true
```

| source class | `RemoveClass("a")` gives | should give |
|---|---|---|
| `a a`     | `a`   | (attribute removed) |
| `a a a`   | `a`   | (attribute removed) |
| `a a b`   | `a b` | `b` |
| `b a a`   | `b a` | `b` |

Non-adjacent repeats (`a b a`) happen to work, because they do not share a
space, which is why this has not shown up in the existing tests.

`ToggleClass` has the same expression (`property.go:196`) and the same bug:
toggling `a` off on `class="a a"` leaves the element with `a`, so a following
toggle turns it *off* again instead of on.

Duplicate class names in the source are what triggers this. goquery itself never
creates them -- `AddClass` checks first -- but scraped HTML frequently has them,
and that is the input goquery exists to handle.

## Fix

A small helper that replaces one occurrence at a time, re-scanning from the
start each round, used by both call sites. Everything else about the functions
is unchanged, including whitespace handling: runs of spaces between the classes
that stay are preserved exactly as before, since the fix only affects how many
occurrences are removed.

## Tests

- `TestRemoveClassRepeatedInSource` -- seven class/removal pairs covering
  adjacent, tripled, leading, trailing and interleaved repeats, plus removing
  more than one class at a time; asserts both the resulting attribute and that
  `HasClass` is false for everything removed.
- `TestToggleClassRepeatedInSource` -- toggling off then back on with a repeated
  class.

Without the fix, `TestRemoveClassRepeatedInSource` reports five failing rows
(`class="a a" RemoveClass("a"): got class "a", want ""` and so on) and
`TestToggleClassRepeatedInSource` fails on both toggles.

Gate run on this branch:

- `go test ./...` -- ok
- `go test -race ./...` -- ok
- `go vet ./...` -- clean
- `gofmt -l property.go property_test.go` -- clean (`gofmt -l ./` flags `doc.go`
  and `type.go` on pristine `master` too; untouched here)
